### PR TITLE
Items in the order file are no longer case sensitive

### DIFF
--- a/src/TocDocFxCreation/TocGenerator.cs
+++ b/src/TocDocFxCreation/TocGenerator.cs
@@ -185,9 +185,14 @@ namespace DocFxTocGenerate
 
                 // see if the file is mentioned in the order-list for ordering.
                 int sequence = int.MaxValue;
-                if (order.Contains(Path.GetFileNameWithoutExtension(fi.Name)))
+                string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fi.Name);
+                for (int i = 0; i < order.Count; i++)
                 {
-                    sequence = order.IndexOf(Path.GetFileNameWithoutExtension(fi.Name));
+                    if (order[i].Equals(fileNameWithoutExtension, StringComparison.OrdinalIgnoreCase))
+                    {
+                        sequence = i;
+                        break;
+                    }
                 }
 
                 string title = string.Empty;
@@ -275,9 +280,14 @@ namespace DocFxTocGenerate
                 TocItem newTocItem = new TocItem();
 
                 // if the directory is in the .order file, take the index as sequence nr
-                if (order.Contains(Path.GetFileName(dirInfo.Name)))
+                string directoryName = Path.GetFileName(dirInfo.Name);
+                for (int i = 0; i < order.Count; i++)
                 {
-                    newTocItem.Sequence = order.IndexOf(Path.GetFileName(dirInfo.Name));
+                    if (order[i].Equals(directoryName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        newTocItem.Sequence = i;
+                        break;
+                    }
                 }
 
                 string title = string.Empty;


### PR DESCRIPTION
I propose that items in the order file are no longer case sensitive because I name my readme files: ```Readme.md```.

There is an automatic system that allows the readme file to be in the first position, however in the code we add README. This does not allow me to take advantage of this feature.

```csharp
// we always want to order README.md. So add it if not in list yet
string readmeEntry = order.FirstOrDefault(x => string.Equals("README", x, StringComparison.OrdinalIgnoreCase));
if (string.IsNullOrEmpty(readmeEntry))
{
    order.Add("README");
    message.Verbose($"'README' added to order-list");
}
```