### PR TITLE
Adding ability to ignore a folder

### DIFF
--- a/src/TocDocFxCreation/Domain/CommandlineOptions.cs
+++ b/src/TocDocFxCreation/Domain/CommandlineOptions.cs
@@ -41,6 +41,12 @@ namespace TocDocFxCreation.Domain
         public bool UseOverride { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the .order files are used.
+        /// </summary>
+        [Option('g', "ignore", Required = false, HelpText = "Use the .ignore files for TOC directory ignore. Format are raws of directory names: directory-to-ignore")]
+        public bool UseIgnore { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether an index is automatically added.
         /// </summary>
         [Option('i', "index", Required = false, HelpText = "Auto-generate a file index in each folder.")]

--- a/src/TocDocFxCreation/README.md
+++ b/src/TocDocFxCreation/README.md
@@ -13,6 +13,7 @@ TocGenerator -d <docs folder> [-o <output folder>] [-vsi]
 -s, --sequence        Use the .order files for TOC sequence. Format are raws of: filename-without-extension
 -r, --override        Use the .override files for TOC file name override. Format are raws of: filename-without-extension;Title you want
 -i, --index           Auto-generate a file index in each folder.
+-g, --ignore          Use the .ignore files for TOC directory ignore. Format are raws of directory names: directory-to-ignore
 --help                Display this help screen.
 --version             Display version information.
 ```


### PR DESCRIPTION
This is useful when you want to ignore a folder. When the documentation is mixed with code for example containing some other md files.
The .ignore file so far supports only folder. That can be extended later to files if that makes sense.