### PR TITLE
Improvement for DocLinkChecker

### DIFF
--- a/src/DocLinkChecker/Helpers/ExitCodeHelper.cs
+++ b/src/DocLinkChecker/Helpers/ExitCodeHelper.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
+// DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+
+namespace DocLinkChecker.Helpers
+{
+    using System;
+
+    /// <summary>
+    /// Helper methods to set the exit code.
+    /// </summary>
+    public static class ExitCodeHelper
+    {
+        private static int exitCode;
+
+        /// <summary>
+        /// Possible exit codes.
+        /// </summary>
+        public enum ExitCodes
+        {
+            /// <summary>
+            /// Exit code for seccessful execution.
+            /// </summary>
+            OK = 0,
+
+            /// <summary>
+            /// Exit code for parsing error.
+            /// </summary>
+            ParsingError = 1,
+
+            /// <summary>
+            /// Exit code for incorrect table format detected.
+            /// </summary>
+            TableFormatError = 2,
+
+            /// <summary>
+            /// Exit code for unkonown exception.
+            /// </summary>
+            UnknownExceptionError = 999,
+        }
+
+        /// <summary>
+        /// Gets or sets default exit code.
+        /// </summary>
+        public static ExitCodes ExitCode
+        {
+            get
+            {
+                return (ExitCodes)exitCode;
+            }
+
+            set
+            {
+                if (Enum.IsDefined(typeof(ExitCodes), value))
+                {
+                    exitCode = (int)value;
+                }
+                else
+                {
+                    exitCode = (int)ExitCodes.UnknownExceptionError;
+                }
+            }
+        }
+    }
+}

--- a/src/DocLinkChecker/README.md
+++ b/src/DocLinkChecker/README.md
@@ -22,14 +22,28 @@ If normal return code of the tool is 0, but on error it returns 1.
 
 If the tool encounters situations that might need some action, a warning is written to the output. The table of contents is still created.
 
-If the tool encounters an error, an error message is written to the output. The table of contents will not be created. The tool will return errorcode 1.
+If the tool encounters an error, an error message is written to the output. The table of contents will not be created.
+
+| Exit Code | Description |
+| :--- | :--- |
+| 0 | Execution has finished successfully |
+| 1 | Arguments Parsing Exception |
+| 2 | Incorrect Table Format |
+| 999 | Unknown Exception |
 
 If you want to trace what the tool is doing, use the `-v or verbose` flag to output all details of processing the files and folders and creating the table of contents.
 
-## What it checks
+## What it checks for links
 
 The tool will track all use of `[]()`. If the link is a web URL, an internal reference (starting with a '#') an e-mail address or a reference to a folder, it's not checked. Other links are checked if they exist in the existing docs hierarchy or on local disc (for code references). Errors are written to the ouput mentioning the filename, the linenumber and position in the line. In the check we also decode the references to make sure we properly check HTML enccoded strings as well (using %20 for instance).
 
 All references are stored in a table to use in the check of the .attachments folder (with the -a flag). All files in this folder that are not referenced are marked as 'unreferenced'. If the -c flag is provided as well, the files are removed from the .attachments folder.
 
-It can also check all table definitions if they are properly formatted.
+## What it checks for tables
+
+The tool will check that tables are well formed. Here are the rules to respect:
+
+- There should be an empty line before the table (it is required to get proper output from DocFX).
+- Tables should start with the character `|` and ends with the same character.
+- Tables are at least 2 columns
+- The second line of the table should be with at least 3 characters `-` as separators


### PR DESCRIPTION
- Improve error code return
- Improve table check when separator is used ( | example `| somethinghere` |), previously would find 3 separators while only 2 are really used