### PR TITLE
Jrmoulckers/root relative link support

### DIFF
--- a/DocExamples/docs/markdown-creation.md
+++ b/DocExamples/docs/markdown-creation.md
@@ -22,7 +22,9 @@ Please to follow those simple rules:
 
 It's ok to use external links.
 
-For links on documentation itself, please use relative link to the file. For example if you are in `/docs/userdocs/en/plant-production` and want to reference the document `index.md` which is located in `/docs/userdocs`, the link will be `../../index.md`
+For links on documentation itself, please use relative link to the file. For example if you are in `/docs/userdocs/en/plant-production` and want to reference the document `index.md` which is located in `/docs/userdocs`, the link will be `../../index.md`.
+
+You may also use relative links to the root of a DocFX project. For example [this link](~/userdocs/index.md) references `/docs/userdocs/index.md` from this very page using a link relative to the project root. The link for this scenario would be `~/userdocs/index.md`. This only works in a Docfx project.
 
 ## Markdown lint
 

--- a/src/DocLinkChecker/Program.cs
+++ b/src/DocLinkChecker/Program.cs
@@ -79,6 +79,8 @@ namespace DocLinkChecker
                 return;
             }
 
+            ValidateDocFolder(options.DocFolder);
+
             // we start at the root to generate the TOC items
             rootDir = new DirectoryInfo(options.DocFolder);
             WalkDirectoryTree(rootDir);
@@ -96,6 +98,24 @@ namespace DocLinkChecker
         private static void HandleErrors(IEnumerable<Error> errors)
         {
             returnvalue = 1;
+        }
+
+        /// <summary>
+        /// Validate that the root directory is a valid DocFX root.
+        /// If the directory is not valid, warn the caller.
+        /// </summary>
+        private static void ValidateDocFolder(string docfolder)
+        {
+            message.Verbose($"Validating documentation folder {docfolder}");
+
+            const string docFXProjectFile = "docfx.json";
+            List<string> rootFiles = Directory.GetFiles(docfolder).ToList().ConvertAll(f => Path.GetFileName(f).ToLowerInvariant());
+
+            // notify client if root directory does not include docfx.json file
+            if (!rootFiles.Contains(docFXProjectFile))
+            {
+                message.Warning("Documentation folder does not contain docfx.json file. Links relative to project root (i.e. ~/path/from/root) may not be properly identified.");
+            }
         }
 
         /// <summary>

--- a/src/DocLinkChecker/Program.cs
+++ b/src/DocLinkChecker/Program.cs
@@ -23,6 +23,7 @@ namespace DocLinkChecker
         private static int returnvalue;
         private static MessageHelper message;
 
+        private static DirectoryInfo rootDir;
         private static List<string> allFiles = new List<string>();
         private static List<string> allLinks = new List<string>();
 
@@ -79,7 +80,7 @@ namespace DocLinkChecker
             }
 
             // we start at the root to generate the TOC items
-            DirectoryInfo rootDir = new DirectoryInfo(options.DocFolder);
+            rootDir = new DirectoryInfo(options.DocFolder);
             WalkDirectoryTree(rootDir);
 
             if (options.Attachments)
@@ -336,7 +337,17 @@ namespace DocLinkChecker
                             !string.IsNullOrWhiteSpace(relative))
                         {
                             // check validity of the link
-                            string absolute = Path.GetFullPath(relative, folder.FullName);
+                            string absolute;
+                            if (relative.StartsWith("~/"))
+                            {
+                                // link is relative to project root directory
+                                absolute = Path.GetFullPath(relative.Substring(2), rootDir.FullName);
+                            }
+                            else
+                            {
+                                // link is relative to its directory
+                                absolute = Path.GetFullPath(relative, folder.FullName);
+                            }
 
                             // check that paths are relative
                             if (Path.IsPathFullyQualified(relative))


### PR DESCRIPTION
Changes:
- Added support for links relative to root directory (i.e.: ~/link/to/index.md)
- Added check for invalid docfolder and warning presented to user
  -  Needed in the case of root relative links - invalid docfolder renders them invalid
- Added E2E scenario to DocExamples of a link relative to the DocFX project root

Links:
- Issue #12 

Tests:
- Validated on MS team's documentation (heavily populated with root relative links)
- Validated on DocExamples project with added scenario:
  - Validates changes on DocExamples project: [valid.txt](https://github.com/Ellerbach/docfx-companion-tools/files/10006500/valid.txt)
  - Validates changes on DocExamples project: [invalid.txt](https://github.com/Ellerbach/docfx-companion-tools/files/10006501/invalid.txt)
    - Locally added invalid root-relative link `~/userdocs/hello.md` inside file `DocExamples/docs/markdown-creation.md`

TODO: 
- Add labels: Bug, Feature