### PR TITLE
Fix edge cases in link check

### DIFF
--- a/src/DocLinkChecker/Program.cs
+++ b/src/DocLinkChecker/Program.cs
@@ -455,16 +455,36 @@ namespace DocLinkChecker
                                                 // Get rid of the title mark
                                                 var lineTitleLink = lineTitle.Replace("#", string.Empty);
 
+                                                // check if there is an HTML link ID like this: ## <a id=\"i_am_an_id\">Title for ID</a>
+                                                Regex idLinkPattern = new Regex(@"(?><a id=\"")(?<id_label>[a-zA-Z -_]+)(?>\"">)");
+                                                if (idLinkPattern.IsMatch(lineTitleLink))
+                                                {
+                                                    // we have a match for this pattern!
+
+                                                    // check if the label id matches
+                                                    if (idLinkPattern.Match(lineTitleLink).Groups["id_label"].Value == afterSharp)
+                                                    {
+                                                        found = true;
+                                                        break;
+                                                    }
+
+                                                    // proceed with replacing the HTML link ID
+                                                    lineTitleLink = idLinkPattern.Replace(lineTitleLink, string.Empty);
+
+                                                    // and the closing link tag too
+                                                    lineTitleLink = lineTitleLink.Replace("</a>", string.Empty);
+                                                }
+
                                                 // Remove the space
                                                 lineTitleLink = lineTitleLink.TrimStart();
 
                                                 // To lower
                                                 lineTitleLink = lineTitleLink.ToLower();
 
-                                                // Remove bold and italic as well as the . and few others
+                                                // Remove bold and italic as well as the . ? and few others
                                                 lineTitleLink = lineTitleLink.Replace("*", string.Empty).Replace(".", string.Empty).Replace("'", string.Empty)
-                                                    .Replace("\"", string.Empty).Replace("_", string.Empty).Replace("/", string.Empty).Replace("&", string.Empty)
-                                                    .Replace("(", string.Empty).Replace(")", string.Empty).Replace("`", string.Empty);
+                                                    .Replace("\"", string.Empty).Replace("/", string.Empty).Replace("&", string.Empty)
+                                                    .Replace("(", string.Empty).Replace(")", string.Empty).Replace("`", string.Empty).Replace("?", string.Empty);
 
                                                 // Replave spaces by dash
                                                 lineTitleLink = lineTitleLink.Replace(" ", "-");


### PR DESCRIPTION
- Add processing for HTML link IDs in format `## <a id=\"i_am_an_id\">Title for ID</a>`.
- Replacer now replaces `?`.
- Replacer doesn't replace `_` anymore as that's a valid char for a tile.

Checked locally by validating this repo/commit: [nanoframework/nanoframework.github.io](https://github.com/nanoframework/nanoframework.github.io/commit/fd9aa64df4add91ad8bee541612e41e3fe2c3934)

Fixing issues wrongly reported in this build: https://dev.azure.com/nanoframework/nanoframework%20docs/_build/results?buildId=38903&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=72c3483f-759b-5fe1-97d0-7523409e045c

```text
D:\a\1\s\content\architecture\simplifications-and-trade-offs.md 33:123
In doc link was not found 'string-format-examples.md#d-decimal'. Make sure you have all lowercase, remove '*' and replace spaces by '-'.
D:\a\1\s\content\architecture\simplifications-and-trade-offs.md 34:127
In doc link was not found 'string-format-examples.md#f-fixed-point'. Make sure you have all lowercase, remove '*' and replace spaces by '-'.
D:\a\1\s\content\architecture\simplifications-and-trade-offs.md 35:123
In doc link was not found 'string-format-examples.md#g-general'. Make sure you have all lowercase, remove '*' and replace spaces by '-'.
D:\a\1\s\content\architecture\simplifications-and-trade-offs.md 36:122
In doc link was not found 'string-format-examples.md#n-number'. Make sure you have all lowercase, remove '*' and replace spaces by '-'.
D:\a\1\s\content\architecture\simplifications-and-trade-offs.md 37:127
In doc link was not found 'string-format-examples.md#x-hexadecimal'. Make sure you have all lowercase, remove '*' and replace spaces by '-'.
D:\a\1\s\content\building\cmake-presets.md 13:21
In doc link was not found '../faq/automatic-firmware-updates.md#how-to-prevent-a-board-from-updating-if-working-on-a-custom-firmware'. Make sure you have all lowercase, remove '*' and replace spaces by '-'.
D:\a\1\s\content\building\cmake-presets.md 14:36
In doc link was not found 'build-instructions.md#build_version-matching'. Make sure you have all lowercase, remove '*' and replace spaces by '-'.
D:\a\1\s\content\building\cmake-presets.md 112:61
In doc link was not found '../architecture/wire-protocol.md#crc32-validatons'. Make sure you have all lowercase, remove '*' and replace spaces by '-'.
D:\a\1\s\content\contributing\contributing-workflow.md 91:22
```