### PR TITLE
Added flag for handling index.md generation with 1 file in folder in DocFxTocGenerator

### DIFF
--- a/src/DocFxTocGenerator/DocFxTocGenerator.csproj
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.csproj
@@ -13,5 +13,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.5.0" />
   </ItemGroup>
 </Project>

--- a/src/DocFxTocGenerator/Domain/CommandlineOptions.cs
+++ b/src/DocFxTocGenerator/Domain/CommandlineOptions.cs
@@ -51,5 +51,12 @@ namespace DocFxTocGenerator.Domain
         /// </summary>
         [Option('i', "index", Required = false, HelpText = "Auto-generate a file index in each folder.")]
         public bool AutoIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether an to now generate an index in a folder with 1 file.
+        /// Is supplementary to the -i option and doesn't work without that flag.
+        /// </summary>
+        [Option('n', "notwithone", Required = false, HelpText = "Do not auto-generate a file index when only contains 1 file. Additional to -i flag.")]
+        public bool NoAutoIndexWithOneFile { get; set; }
     }
 }


### PR DESCRIPTION
Changes to the **DocFxTocGenerator** tool:
* Standard behavior is still: if no INDEX.md or README.md is found, an INDEX.md is added to a folder (-i flag)
* Adding the -n flag to the -i will prevent generating an INDEX.md if there is only 1 file in the folder. In that case, that file is used as the reference for a folder.
* Changed to way to get the hierarchy of folders and files to improve performance.