### PR TITLE
FIX: removed filter on INDEX.md to process existing ones

### DIFF
--- a/src/DocFxTocGenerator/TocGenerator.cs
+++ b/src/DocFxTocGenerator/TocGenerator.cs
@@ -193,7 +193,6 @@ namespace DocFxTocGenerator
                 _filePatternsForToc
                 .SelectMany(pattern => folder.GetFiles(pattern, _caseSetting))
                 .OrderBy(f => f.Name)
-                .Where(f => f.Name.ToUpperInvariant() != "INDEX.MD")
                 .ToList();
             if (!files.Any())
             {


### PR DESCRIPTION
We filtered out INDEX.md from the list of files in a folder. This resulted in skipping the processing of existing INDEX.md files in the order or the TOC. Removed that filter from the query.