### PR TITLE
Excluded ftp, xref and mailto protocols from validation.

### DIFF
--- a/src/DocLinkChecker/Program.cs
+++ b/src/DocLinkChecker/Program.cs
@@ -385,7 +385,10 @@ namespace DocLinkChecker
                         // check link if not to a URL, in-doc link or e-mail address
                         if (!relative.StartsWith("http:") &&
                             !relative.StartsWith("https:") &&
-                            !relative.Contains("@") &&
+                            !relative.StartsWith("ftp:") &&
+                            !relative.StartsWith("ftps:") &&
+                            !relative.StartsWith("xref:") &&
+                            !relative.StartsWith("mailto:") &&
                             !string.IsNullOrEmpty(Path.GetExtension(relative)) &&
                             !string.IsNullOrWhiteSpace(relative))
                         {


### PR DESCRIPTION
**DocLinkChecker**
* Excluded ftp, ftps, xref and mailto protocols from link validation
* Removed check for link containing @ sign to recognize email address. Covered by check for mailto protocol