### PR TITLE
Fix: Success Code on 0 errors and warnings

### DIFF
--- a/src/DocLinkChecker/DocLinkChecker/App.cs
+++ b/src/DocLinkChecker/DocLinkChecker/App.cs
@@ -129,6 +129,10 @@
                         Program.ReturnValue = ReturnValue.Success;
                     }
                 }
+                else
+                {
+                    Program.ReturnValue = ReturnValue.Success;
+                }
 
                 foreach (MarkdownError error in errors)
                 {


### PR DESCRIPTION
If you have no errors or warnings the tool would incorrectly exit with a code of -1 rather than 0