### PR TITLE
Small logging changes.

### DIFF
--- a/src/DocLinkChecker/DocLinkChecker/Program.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Program.cs
@@ -135,7 +135,7 @@ namespace DocLinkChecker
             {
                 if (File.Exists(AppConstants.AppConfigFileName))
                 {
-                    console.Error($"***ERROR: {AppConstants.AppConfigFileName} already exists in this folder. We don't overwrite.");
+                    console.Error($"*** ERROR: {AppConstants.AppConfigFileName} already exists in this folder. We don't overwrite.");
 
                     // indicate we're done with an error
                     ReturnValue = ReturnValue.CommandError;
@@ -196,7 +196,7 @@ namespace DocLinkChecker
                 _appConfig.ConfigFilePath = Path.GetFullPath(o.ConfigFilePath);
                 if (!File.Exists(o.ConfigFilePath))
                 {
-                    console.Error($"***ERROR: configuration file {o.ConfigFilePath} not found.");
+                    console.Error($"*** ERROR: configuration file {o.ConfigFilePath} not found.");
 
                     // indicate we're done with errors in the configuration file
                     ReturnValue = ReturnValue.ConfigurationFileErrors;
@@ -218,7 +218,7 @@ namespace DocLinkChecker
                 }
                 catch (Exception ex)
                 {
-                    console.Error($"***ERROR: reading {o.ConfigFilePath} - {ex.Message}");
+                    console.Error($"*** ERROR: reading {o.ConfigFilePath} - {ex.Message}");
 
                     // indicate we're done with errors in the configuration file
                     ReturnValue = ReturnValue.ConfigurationFileErrors;
@@ -234,7 +234,7 @@ namespace DocLinkChecker
 
             if (string.IsNullOrEmpty(_appConfig.DocumentationFiles.SourceFolder))
             {
-                console.Error("***ERROR: No document folder was configured, either through -d or in the config file.");
+                console.Error("*** ERROR: No document folder was configured, either through -d or in the config file.");
                 ReturnValue = ReturnValue.ConfigurationFileErrors;
                 return;
             }

--- a/src/DocLinkChecker/DocLinkChecker/Services/CrawlerService.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Services/CrawlerService.cs
@@ -77,7 +77,7 @@
                 }
                 catch (Exception ex)
                 {
-                    _console.Error($"*** ERROR: {ex.Message}");
+                    _console.Verbose($"*** ERROR in {nameof(ParseMarkdownFiles)} processing {file} [ignored]: {ex.Message}.\n{ex}");
                 }
             }
 

--- a/src/DocLinkChecker/DocLinkChecker/Services/LinkValidatorService.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Services/LinkValidatorService.cs
@@ -7,6 +7,7 @@
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
     using DocLinkChecker.Enums;

--- a/src/DocLinkChecker/DocLinkChecker/Services/ResourceValidatorService.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Services/ResourceValidatorService.cs
@@ -80,7 +80,7 @@
                 }
                 catch (Exception ex)
                 {
-                    _console.Error($"*** ERROR: {ex.Message}");
+                    _console.Verbose($"*** ERROR in {nameof(CheckForOrphanedResources)} processing {resource} [ignored]: {ex.Message}.\n{ex}");
                 }
             }
 


### PR DESCRIPTION
I changed some logging to use standard spacing.

Also changed logging in CrawlerService and ResourceValidatorService to further investigate the error "Length cannot be less than zero" that pops up now and then. Those errors are now ignored, but in verbose mode a stack trace is shown to further investigate the scenario which is causing these errors (and where).