### PR TITLE
Doclinkchecker unicode fix

### DIFF
--- a/src/DocLinkChecker/DocLinkChecker.Test/Helpers/MarkdownExtensions.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/Helpers/MarkdownExtensions.cs
@@ -48,6 +48,17 @@ namespace DocLinkChecker.Test.Helpers
             return s + Environment.NewLine + content;
         }
 
+        internal static string AddCodeLink(this string s, string name, string url)
+        {
+            Faker faker = new Faker();
+            string content = $" [!code-csharp[{name}]({url})]" + Environment.NewLine;
+            if (string.IsNullOrEmpty(s))
+            {
+                return content;
+            }
+            return s + Environment.NewLine + content;
+        }
+
         internal static string AddTableStart(this string s, int columns = 3)
         {
             Faker faker = new Faker();
@@ -101,6 +112,15 @@ namespace DocLinkChecker.Test.Helpers
                 return markdown;
             }
             return s + markdown;
+        }
+
+        internal static string AddRawContent(this string s, string content)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return content;
+            }
+            return s + content;
         }
     }
 }

--- a/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
@@ -295,49 +295,6 @@
             service.Errors.First().Message.Should().Contain("Full path not allowed");
         }
 
-        [Fact]
-        public async void ValidateCodeReferenceFile()
-        {
-            // Arrange
-            _config.DocumentationFiles.SourceFolder = _fileServiceMock.Root;
-            _config.DocLinkChecker.RelativeLinkStrategy = RelativeLinkType.All;
-
-            string foo = "scripts/foo.cs";
-            string fooPath = Path.GetFullPath(Path.Combine(_fileServiceMock.Root, foo));
-            string empty = string.Empty;
-            _fileServiceMock.Files.Add(fooPath, empty.AddRawContent(
-@"// (other content above)
-
-// <Bravo>
-foreach(var thing in list)
-{
-     // Do Stuff
-}
-// </Bravo>
-"));
-            string bar = "scripts/bar.cs";
-            string barPath = Path.GetFullPath(Path.Combine(_fileServiceMock.Root, bar));
-            _fileServiceMock.Files.Add(barPath, empty.AddRawContent(
-@"private void MyMethod()
-{
-   #region starting
-   // Some code
-   #endregion
-}
-"));
-
-            LinkValidatorService service = new LinkValidatorService(_serviceProvider, _config, _fileService, _console);
-
-            //Act
-            int line = 124;
-            int column = 3381;
-            Hyperlink link = new Hyperlink($"{_fileServiceMock.Root}\\index.md", line, column, "[!code-csharp[Code](scripts/foo.cs)]");
-            await service.VerifyHyperlink(link);
-
-            // Assert
-            service.Errors.Where(x => x.Severity == MarkdownErrorSeverity.Error).Should().BeEmpty();
-        }
-
         private ICustomConsoleLogger GetMockedConsoleLogger()
         {
             Mock<ICustomConsoleLogger> console = new Mock<ICustomConsoleLogger>();

--- a/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
@@ -295,6 +295,49 @@
             service.Errors.First().Message.Should().Contain("Full path not allowed");
         }
 
+        [Fact]
+        public async void ValidateCodeReferenceFile()
+        {
+            // Arrange
+            _config.DocumentationFiles.SourceFolder = _fileServiceMock.Root;
+            _config.DocLinkChecker.RelativeLinkStrategy = RelativeLinkType.All;
+
+            string foo = "scripts/foo.cs";
+            string fooPath = Path.GetFullPath(Path.Combine(_fileServiceMock.Root, foo));
+            string empty = string.Empty;
+            _fileServiceMock.Files.Add(fooPath, empty.AddRawContent(
+@"// (other content above)
+
+// <Bravo>
+foreach(var thing in list)
+{
+     // Do Stuff
+}
+// </Bravo>
+"));
+            string bar = "scripts/bar.cs";
+            string barPath = Path.GetFullPath(Path.Combine(_fileServiceMock.Root, bar));
+            _fileServiceMock.Files.Add(barPath, empty.AddRawContent(
+@"private void MyMethod()
+{
+   #region starting
+   // Some code
+   #endregion
+}
+"));
+
+            LinkValidatorService service = new LinkValidatorService(_serviceProvider, _config, _fileService, _console);
+
+            //Act
+            int line = 124;
+            int column = 3381;
+            Hyperlink link = new Hyperlink($"{_fileServiceMock.Root}\\index.md", line, column, "[!code-csharp[Code](scripts/foo.cs)]");
+            await service.VerifyHyperlink(link);
+
+            // Assert
+            service.Errors.Where(x => x.Severity == MarkdownErrorSeverity.Error).Should().BeEmpty();
+        }
+
         private ICustomConsoleLogger GetMockedConsoleLogger()
         {
             Mock<ICustomConsoleLogger> console = new Mock<ICustomConsoleLogger>();

--- a/src/DocLinkChecker/DocLinkChecker.Test/MarkdownTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/MarkdownTests.cs
@@ -54,17 +54,6 @@
                 .AddNewLine()
                 .AddParagraphs(2);
 
-        private string _codeLinkingDocument = string.Empty
-                .AddHeading("Code Linking Document", 1)
-                .AddParagraphs(1).AddCodeLink("Code", "scripts/foo.cs")
-                .AddParagraphs(1).AddCodeLink("Code", "scripts/foo.cs?name=Bravo")
-                .AddNewLine()
-                .AddParagraphs(1).AddCodeLink(string.Empty, "scripts/bar.cs#starting")
-                .AddParagraphs(1).AddCodeLink(string.Empty, "scripts/bar.cs#L3-5")
-                .AddParagraphs(1).AddCodeLink(string.Empty, "scripts/bar.cs?highlight=2,5-7,9-)")
-                .AddNewLine()
-                .AddParagraphs(2);
-
         [Fact]
         public void FindAllLinks()
         {
@@ -130,13 +119,6 @@
         {
             var result = MarkdownHelper.ParseMarkdownString(string.Empty, _errorDocument, true);
             result.errors.Count.Should().Be(5);
-        }
-
-        [Fact]
-        public void FindAllCodeLinks()
-        {
-            var result = MarkdownHelper.ParseMarkdownString(string.Empty, _codeLinkingDocument, false);
-            result.errors.Should().BeEmpty();
         }
     }
 }

--- a/src/DocLinkChecker/DocLinkChecker/Helpers/MarkdownHelper.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Helpers/MarkdownHelper.cs
@@ -80,7 +80,9 @@
                     // custom generation of the id
                     string id = title.ToLower();
                     id = Regex.Replace(id, "[ _]", "-");
-                    id = Regex.Replace(id, "[^a-zA-Z0-9-]*", string.Empty);
+
+                    // replace all non-characters. \p[L] takes all unicode variants in account as well like ö and á
+                    id = Regex.Replace(id, @"[^\p{L}0-9-]*", string.Empty);
 
                     return new Heading(markdownFilePath, x.Line + 1, x.Column + 1, title, id);
                 })

--- a/src/DocLinkChecker/DocLinkChecker/Properties/launchSettings.json
+++ b/src/DocLinkChecker/DocLinkChecker/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "DocLinkChecker": {
-      "commandName": "Project",
-      "commandLineArgs": "-d \"D:\\Git\\CSE\\LSEG\\LSEG-ef-doc\\docs\" -tavx -f \"D:\\Git\\CSE\\ZF\\DMPwork\\docfx-companion-tools.json\""
-    }
-  }
-}


### PR DESCRIPTION
Added support for the use of UNICODE characters like á or ö in markdown headings.