### PR TITLE
Change tool name in documentation readme of DocFxTocGenerator

### DIFF
--- a/src/DocFxTocGenerator/README.md
+++ b/src/DocFxTocGenerator/README.md
@@ -5,7 +5,7 @@ This tool allow to generate a yaml compatible `toc.yml` file for DocFX.
 ## Usage
 
 ```text
-TocGenerator -d <docs folder> [-o <output folder>] [-vsi]
+DocFxTocGenerator -d <docs folder> [-o <output folder>] [-vsi]
 
 -d, --docfolder          Required. Folder containing the documents.
 -o, --outputfolder       Folder to write the resulting toc.yml in.


### PR DESCRIPTION
Changed the tool name in the DocFxTocGenerator reamde, to match the tool name in the main readme.
Otherwise the shown command does not work with the newest version.