### PR TITLE
Added support to specify a single source file

### DIFF
--- a/src/DocFxOpenApi/DocFxOpenApi.cs
+++ b/src/DocFxOpenApi/DocFxOpenApi.cs
@@ -75,13 +75,13 @@ namespace DocFxOpenApi
                 _options.OutputFolder = _options.SpecFolder;
             }
 
-            _message.Verbose($"Specification folder: {_options.SpecFolder}");
+            _message.Verbose($"Specification file/folder: {_options.SpecFolder ?? _options.SpecFile}");
             _message.Verbose($"Output folder       : {_options.OutputFolder}");
             _message.Verbose($"Verbose             : {_options.Verbose}");
 
-            if (!Directory.Exists(_options.SpecFolder))
+            if ((_options.SpecFolder ?? _options.SpecFile) == null)
             {
-                _message.Error($"ERROR: Specification folder '{_options.SpecFolder}' doesn't exist.");
+                _message.Error($"ERROR: Specification folder/file '{_options.SpecSource}' doesn't exist.");
                 _returnvalue = 1;
                 return;
             }
@@ -93,9 +93,16 @@ namespace DocFxOpenApi
 
         private void ConvertOpenApiFiles()
         {
-            foreach (var extension in _openApiFileExtensions)
+            if (_options.SpecFolder != null)
             {
-                this.ConvertOpenApiFiles(extension);
+                foreach (var extension in _openApiFileExtensions)
+                {
+                    this.ConvertOpenApiFiles(extension);
+                }
+            }
+            else
+            {
+                this.ConvertOpenApiFile(_options.SpecFile!);
             }
         }
 

--- a/src/DocFxOpenApi/Domain/CommandlineOptions.cs
+++ b/src/DocFxOpenApi/Domain/CommandlineOptions.cs
@@ -7,12 +7,12 @@ namespace DocFxOpenApi.Domain
     using CommandLine;
 
     /// <summary>
-    ///     Class for command line options.
+    ///  Class for command line options.
     /// </summary>
     public class CommandlineOptions
     {
         /// <summary>
-        ///     Gets or sets the folder with specifications.
+        /// Gets or sets the folder with specifications.
         /// </summary>
         [Option('s', "specsource", Required = true, HelpText = "Folder or File containing the OpenAPI specification.")]
         public string? SpecSource
@@ -22,24 +22,24 @@ namespace DocFxOpenApi.Domain
         }
 
         /// <summary>
-        ///     Gets or sets the output folder.
+        /// Gets or sets the output folder.
         /// </summary>
         [Option('o', "outputfolder", Required = false, HelpText = "Folder to write the resulting specifications in.")]
         public string? OutputFolder { get; set; }
 
         /// <summary>
-        ///     Gets or sets a value indicating whether verbose information is shown in the output.
+        /// Gets or sets a value indicating whether verbose information is shown in the output.
         /// </summary>
         [Option('v', "verbose", Required = false, HelpText = "Show verbose messages.")]
         public bool Verbose { get; set; }
 
         /// <summary>
-        ///     Gets the folder with specifications, if the source is a folder.
+        /// Gets the folder with specifications, if the source is a folder.
         /// </summary>
         public string? SpecFolder { get; private set; }
 
         /// <summary>
-        ///     Gets the file with specifications, if the source is a file.
+        /// Gets the file with specifications, if the source is a file.
         /// </summary>
         public string? SpecFile { get; private set; }
 

--- a/src/DocFxOpenApi/Domain/CommandlineOptions.cs
+++ b/src/DocFxOpenApi/Domain/CommandlineOptions.cs
@@ -3,29 +3,61 @@
 
 namespace DocFxOpenApi.Domain
 {
+    using System.IO;
     using CommandLine;
 
     /// <summary>
-    /// Class for command line options.
+    ///     Class for command line options.
     /// </summary>
     public class CommandlineOptions
     {
         /// <summary>
-        /// Gets or sets the folder with specifications.
+        ///     Gets or sets the folder with specifications.
         /// </summary>
-        [Option('s', "specfolder", Required = true, HelpText = "Folder containing the OpenAPI specification.")]
-        public string? SpecFolder { get; set; }
+        [Option('s', "specsource", Required = true, HelpText = "Folder or File containing the OpenAPI specification.")]
+        public string? SpecSource
+        {
+            get => SpecFolder ?? SpecFile;
+            set => SetSource(value);
+        }
 
         /// <summary>
-        /// Gets or sets the output folder.
+        ///     Gets or sets the output folder.
         /// </summary>
         [Option('o', "outputfolder", Required = false, HelpText = "Folder to write the resulting specifications in.")]
         public string? OutputFolder { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether verbose information is shown in the output.
+        ///     Gets or sets a value indicating whether verbose information is shown in the output.
         /// </summary>
         [Option('v', "verbose", Required = false, HelpText = "Show verbose messages.")]
         public bool Verbose { get; set; }
+
+        /// <summary>
+        ///     Gets the folder with specifications, if the source is a folder.
+        /// </summary>
+        public string? SpecFolder { get; private set; }
+
+        /// <summary>
+        ///     Gets the file with specifications, if the source is a file.
+        /// </summary>
+        public string? SpecFile { get; private set; }
+
+        private void SetSource(string? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            if (Directory.Exists(value))
+            {
+                SpecFolder = value;
+            }
+            else if (File.Exists(value))
+            {
+                SpecFile = value;
+            }
+        }
     }
 }

--- a/src/DocFxOpenApi/README.md
+++ b/src/DocFxOpenApi/README.md
@@ -6,14 +6,15 @@ This tool converts existing [OpenAPI](https://www.openapis.org/) specification f
 
 ```text
 DocFxOpenApi -s <specs folder> [-o <output folder>] [-v]
-  -s, --specfolder        Required. Folder containing the OpenAPI specification.
+  -s, --specsource      Required. Folder or file containing the OpenAPI specification.
   -o, --outputfolder	Folder to write the resulting specifications in.
-  -v, --verbose           Show verbose messages.
-  --help                	  Display this help screen.
-  --version              	Display version information.
+  -v, --verbose         Show verbose messages.
+  --help                Display this help screen.
+  --version             Display version information.
 ```
 
-The tool converts any `*.json`, `*.yaml`, `*.yml` file from the provided specification folder into the output folder. It supports JSON or YAML-format, OpenAPI v2 or v3 (including 3.0.1) format files.
+When a folder is provided to the `specsource` parameter, the tool converts all `*.json`, `*.yaml`, `*.yml` files in the folder and its subfolders. When a file is provided, the tool converts only that file.
+It supports JSON or YAML-format, OpenAPI v2 or v3 (including 3.0.1) format files.
 
 If the `-o or --outputfolder` is not provided, the output folder is set to the input specs folder.
 


### PR DESCRIPTION
The current version has a problem that it does not support a single file to be specified as the source - only a folder.
If the source folder has more than one .json or .yml file the program will try to parse them all, throwing errors in the output.

This change introduces the support for a single file to be passed as source for the conversion.