### PR TITLE
Fixed issue with ignoring generated index.md in folder with 1 file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # User-specific files
 *.zip
 [Oo]utput/
+launchSettings.json
 
 *.rsuser
 *.suo

--- a/src/DocFxTocGenerator/TocGenerator.cs
+++ b/src/DocFxTocGenerator/TocGenerator.cs
@@ -403,7 +403,16 @@ namespace DocFxTocGenerator
 
                 if (subFiles.Length == 1 && dirInfo.GetDirectories().Length == 0)
                 {
-                    newTocItem.Href = GetRelativePath(subFiles[0].FullName, _options.DocFolder);
+                    if (!string.IsNullOrEmpty(entryFile))
+                    {
+                        // if we have added an index file, so we'll point to that one
+                        newTocItem.Href = GetRelativePath(entryFile, _options.DocFolder);
+                    }
+                    else
+                    {
+                        // otherwise: the first file.
+                        newTocItem.Href = GetRelativePath(subFiles[0].FullName, _options.DocFolder);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
When a folder has only one markdown document it is automatically picked as entry point for the folder, unless the option `--index` is used to generate an index as well. In that case the generated `index.md` wasn't picked as entry point. With this fix issue #27 is solved.