### PR TITLE
Added validation of root-reference with ~

### DIFF
--- a/src/DocLinkChecker/DocLinkChecker/Models/Hyperlink.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Models/Hyperlink.cs
@@ -1,6 +1,5 @@
 ﻿namespace DocLinkChecker.Models
 {
-    using System.Diagnostics;
     using System.IO;
     using DocLinkChecker.Enums;
 

--- a/src/DocLinkChecker/DocLinkChecker/Services/LinkValidatorService.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Services/LinkValidatorService.cs
@@ -272,18 +272,38 @@
                 return Task.CompletedTask;
             }
 
-            // compute link of the url relative to the path of the file.
-            if (!_fileService.ExistsFileOrDirectory(hyperlink.UrlFullPath))
+            if (hyperlink.Url.StartsWith("~"))
             {
-                // referenced file doesn't exist
-                _errors.Enqueue(
-                    new MarkdownError(
-                        hyperlink.FilePath,
-                        hyperlink.Line,
-                        hyperlink.Column,
-                        MarkdownErrorSeverity.Error,
-                        $"Not found: {hyperlink.Url}"));
-                return Task.CompletedTask;
+                // special case for a reference to the root of the docs. Calculate full path differently.
+                string url = hyperlink.Url.Replace("~", _config.DocumentationFiles.SourceFolder);
+                if (!_fileService.ExistsFileOrDirectory(url))
+                {
+                    // referenced file doesn't exist
+                    _errors.Enqueue(
+                        new MarkdownError(
+                            hyperlink.FilePath,
+                            hyperlink.Line,
+                            hyperlink.Column,
+                            MarkdownErrorSeverity.Error,
+                            $"Not found: {hyperlink.Url}"));
+                    return Task.CompletedTask;
+                }
+            }
+            else
+            {
+                // compute link of the url relative to the path of the file.
+                if (!_fileService.ExistsFileOrDirectory(hyperlink.UrlFullPath))
+                {
+                    // referenced file doesn't exist
+                    _errors.Enqueue(
+                        new MarkdownError(
+                            hyperlink.FilePath,
+                            hyperlink.Line,
+                            hyperlink.Column,
+                            MarkdownErrorSeverity.Error,
+                            $"Not found: {hyperlink.Url}"));
+                    return Task.CompletedTask;
+                }
             }
 
             switch (_config.DocLinkChecker.RelativeLinkStrategy)


### PR DESCRIPTION
DocFx supports the use of a ~ to reference the folder where the docfx.json resides. See [documentation of DocFx](https://dotnet.github.io/docfx/docs/links-and-cross-references.html#link-to-local-files). As we have no knowledge of that file in the DocLinkChecker, we assume that the docfx.json file is in the document root.

With this PR we added the support for the use of ~ to reference the documentation root folder, and we validate if the reference file exists. This test will fail of course if the docfx.json is in another directory.

This PR fixes #50.