### PR TITLE
DocLinkChecker: Support for %20 in links

### DIFF
--- a/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
@@ -306,6 +306,10 @@
         [Theory]
         [InlineData("~/general/images/nature.jpeg")]
         [InlineData("~\\general\\images\\nature.jpeg")]
+        [InlineData("~/general/images/space%20image.jpeg")]
+        [InlineData("~\\general\\images\\space%20image.jpeg")]
+        [InlineData("%7E/general/images/space%20image.jpeg")]
+        [InlineData("%7E\\general\\images\\space%20image.jpeg")]
         public async void ValidateRootLinkShouldHaveNoErrors(string path)
         {
             // Arrange
@@ -327,6 +331,8 @@
         [Theory]
         [InlineData("~/general/images/NON_EXISTING.jpeg")]
         [InlineData("~\\NON_EXISTING\\images\\nature.jpeg")]
+        [InlineData("~/general%2Fimages/nature.jpeg")]
+        [InlineData("~/general/images/space image.jpeg")]
         public async void ValidateInvalidRootLinkShouldHaveErrors(string path)
         {
             // Arrange

--- a/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
@@ -354,6 +354,28 @@
             linkError.Severity.Should().Be(MarkdownErrorSeverity.Error);
         }
 
+        [Theory]
+        // Adopted behaviour from DocFx tests <https://github.com/dotnet/docfx/blob/cca05f505e30c5ede36973c4b989fce711f2e8ad/test/Docfx.Common.Tests/RelativePathTest.cs#L400-L412>
+        // Modified that expected result of Encoded var is upper case, instead of same case as original.
+        [InlineData("a/b/c", "a/b/c")]
+        [InlineData("../a/b/c", "../a/b/c")]
+        [InlineData("a/b/c%20d", "a/b/c d")]
+        [InlineData("../a%2Bb/c/d", "../a+b/c/d")]
+        [InlineData("a%253fb", "a%3fb")]
+        [InlineData("a%2fb", "a%2Fb")]
+        [InlineData("%2A%2F%3A%3F%5C", "%2A%2F%3A%3F%5C")] //*/:?\
+        [InlineData("%2a%2f%3a%3f%5c", "%2A%2F%3A%3F%5C")]
+        public void ValidateLocalUrlDecode(string path, string expected)
+        {
+            //Act
+            int line = 499;
+            int column = 75;
+            Hyperlink link = new Hyperlink(null, line, column, path);
+
+            Assert.Equal(path, link.OriginalUrl);
+            Assert.Equal(expected, link.Url);
+        }
+
         [Fact]
         public async void ValidateLocalLinkWithFullPathShouldHaveErrors()
         {

--- a/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
@@ -332,7 +332,6 @@
         [InlineData("~/general/images/NON_EXISTING.jpeg")]
         [InlineData("~\\NON_EXISTING\\images\\nature.jpeg")]
         [InlineData("~/general%2Fimages/nature.jpeg")]
-        [InlineData("~/general/images/space image.jpeg")]
         public async void ValidateInvalidRootLinkShouldHaveErrors(string path)
         {
             // Arrange

--- a/src/DocLinkChecker/DocLinkChecker.Test/MockFileService.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/MockFileService.cs
@@ -63,6 +63,7 @@
 
             Files.Add($"{Root}\\general\\images\\nature.jpeg", "<image>");
             Files.Add($"{Root}\\general\\images\\another-image.png", "<image>");
+            Files.Add($"{Root}\\general\\images\\space image.jpeg", "<image>");
 
             Files.Add($"{Root}\\src", null);
             Files.Add($"{Root}\\src\\sample.cs", @"namespace MySampleApp;

--- a/src/DocLinkChecker/DocLinkChecker/Models/Hyperlink.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Models/Hyperlink.cs
@@ -48,6 +48,11 @@
                 }
                 else
                 {
+                    // Logic for DocFx RelativePath class is complex <https://github.com/dotnet/docfx/blob/cca05f505e30c5ede36973c4b989fce711f2e8ad/src/Docfx.Common/Path/RelativePath.cs>
+                    // Cannot use `Uri.UnescapeDataString` as it would also decode `%2F` to `/'. DocFX does not do this.
+                    // To avoid writing a complex logic. Just basic replacing of some chars.
+                    Url = Url.Replace("%20", " ").Replace("%7E", "~");
+
                     if (Path.GetExtension(url).ToLower() == ".md" || Path.GetExtension(url) == string.Empty)
                     {
                         // link to an MD file or a folder

--- a/src/DocLinkChecker/DocLinkChecker/Services/LinkValidatorService.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Services/LinkValidatorService.cs
@@ -189,12 +189,12 @@
 
                 if (hyperlink.Url.Matches(whitelist))
                 {
-                    _console.Verbose($"Skipping whitelisted url {hyperlink.Url}");
+                    _console.Verbose($"Skipping whitelisted url {hyperlink.OriginalUrl}");
                     return;
                 }
             }
 
-            _console.Verbose($"Validating {hyperlink.Url} in {_fileService.GetRelativePath(_config.DocumentationFiles.SourceFolder, hyperlink.FilePath)}");
+            _console.Verbose($"Validating {hyperlink.OriginalUrl} in {_fileService.GetRelativePath(_config.DocumentationFiles.SourceFolder, hyperlink.FilePath)}");
             using var scope = _serviceProvider.CreateScope();
             var client = scope.ServiceProvider.GetRequiredService<CheckerHttpClient>();
 
@@ -204,7 +204,7 @@
             sw.Stop();
             if (sw.ElapsedMilliseconds > _config.DocLinkChecker.ExternalLinkDurationWarning)
             {
-                _console.Warning($"*** WARNING: Checking {hyperlink.Url} took {sw.ElapsedMilliseconds}ms.");
+                _console.Warning($"*** WARNING: Checking {hyperlink.OriginalUrl} took {sw.ElapsedMilliseconds}ms.");
             }
 
             if (!result.success)
@@ -229,7 +229,7 @@
                                 hyperlink.Line,
                                 hyperlink.Column,
                                 severity,
-                                $"{hyperlink.Url} => {result.statusCode}"));
+                                $"{hyperlink.OriginalUrl} => {result.statusCode}"));
                     }
                 }
                 else
@@ -241,7 +241,7 @@
                             hyperlink.Line,
                             hyperlink.Column,
                             MarkdownErrorSeverity.Error,
-                            $"{hyperlink.Url} => {result.error}"));
+                            $"{hyperlink.OriginalUrl} => {result.error}"));
                 }
             }
         }
@@ -268,7 +268,7 @@
                         hyperlink.Line,
                         hyperlink.Column,
                         MarkdownErrorSeverity.Error,
-                        $"Full path not allowed as link: {hyperlink.Url}"));
+                        $"Full path not allowed as link: {hyperlink.OriginalUrl}"));
                 return Task.CompletedTask;
             }
 
@@ -285,7 +285,7 @@
                             hyperlink.Line,
                             hyperlink.Column,
                             MarkdownErrorSeverity.Error,
-                            $"Not found: {hyperlink.Url}"));
+                            $"Not found: {hyperlink.OriginalUrl}"));
                     return Task.CompletedTask;
                 }
             }
@@ -301,7 +301,7 @@
                             hyperlink.Line,
                             hyperlink.Column,
                             MarkdownErrorSeverity.Error,
-                            $"Not found: {hyperlink.Url}"));
+                            $"Not found: {hyperlink.OriginalUrl}"));
                     return Task.CompletedTask;
                 }
             }
@@ -317,7 +317,7 @@
                                 hyperlink.Line,
                                 hyperlink.Column,
                                 MarkdownErrorSeverity.Error,
-                                $"File referenced outside of the same /docs hierarchy not allowed: {hyperlink.Url}"));
+                                $"File referenced outside of the same /docs hierarchy not allowed: {hyperlink.OriginalUrl}"));
                         return Task.CompletedTask;
                     }
 
@@ -332,7 +332,7 @@
                                 hyperlink.Line,
                                 hyperlink.Column,
                                 MarkdownErrorSeverity.Error,
-                                $"File referenced outside of anything else then a /docs hierarchy not allowed: {hyperlink.Url}"));
+                                $"File referenced outside of anything else then a /docs hierarchy not allowed: {hyperlink.OriginalUrl}"));
                         return Task.CompletedTask;
                     }
 


### PR DESCRIPTION
Add basic support for `%20` in url. See #60 for details.

Was hoping for a more elegant implementation. But this works.

Fixes #60 