### PR TITLE
DocFxOpenApi: Changes for new rules with .NET8. No logic changes.

### DIFF
--- a/src/DocFxOpenApi/DocFxOpenApi.cs
+++ b/src/DocFxOpenApi/DocFxOpenApi.cs
@@ -1,20 +1,15 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using CommandLine;
+using global::DocFxOpenApi.Domain;
+using global::DocFxOpenApi.Helpers;
+using Microsoft.OpenApi;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
 
 namespace DocFxOpenApi
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using CommandLine;
-    using global::DocFxOpenApi.Domain;
-    using global::DocFxOpenApi.Helpers;
-    using Microsoft.OpenApi;
-    using Microsoft.OpenApi.Extensions;
-    using Microsoft.OpenApi.Models;
-    using Microsoft.OpenApi.Readers;
-
     /// <summary>
     /// Open API file converter to V2 JSON files.
     /// </summary>

--- a/src/DocFxOpenApi/Domain/CommandlineOptions.cs
+++ b/src/DocFxOpenApi/Domain/CommandlineOptions.cs
@@ -1,11 +1,9 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using CommandLine;
 
 namespace DocFxOpenApi.Domain
 {
-    using System.IO;
-    using CommandLine;
-
     /// <summary>
     ///  Class for command line options.
     /// </summary>

--- a/src/DocFxOpenApi/Helpers/MessageHelper.cs
+++ b/src/DocFxOpenApi/Helpers/MessageHelper.cs
@@ -1,11 +1,9 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using global::DocFxOpenApi.Domain;
 
 namespace DocFxOpenApi.Helpers
 {
-    using System;
-    using global::DocFxOpenApi.Domain;
-
     /// <summary>
     /// Helper methods to write messages to the console.
     /// </summary>


### PR DESCRIPTION
* Usings outside namespace
* Proper formatting of new()
* Tuple variables need camel casing