### PR TITLE
DocLanguageTranslator: Changes for new rules with .NET8. No logic changes.

### DIFF
--- a/src/DocLanguageTranslator/Domain/CommandlineOptions.cs
+++ b/src/DocLanguageTranslator/Domain/CommandlineOptions.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using CommandLine;
 
 namespace DocFXLanguageGenerator.Domain
 {
-    using CommandLine;
-
     /// <summary>
     /// Class for command line options.
     /// </summary>

--- a/src/DocLanguageTranslator/Domain/ErrorDetail.cs
+++ b/src/DocLanguageTranslator/Domain/ErrorDetail.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using Newtonsoft.Json;
 
 namespace DocFXLanguageGenerator.Domain
 {
-    using Newtonsoft.Json;
-
     /// <summary>
     /// Error details.
     /// </summary>

--- a/src/DocLanguageTranslator/Domain/ErrorResponse.cs
+++ b/src/DocLanguageTranslator/Domain/ErrorResponse.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using Newtonsoft.Json;
 
 namespace DocFXLanguageGenerator.Domain
 {
-    using Newtonsoft.Json;
-
     /// <summary>
     /// Error response.
     /// </summary>

--- a/src/DocLanguageTranslator/Domain/Translation.cs
+++ b/src/DocLanguageTranslator/Domain/Translation.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using Newtonsoft.Json;
 
 namespace DocFXLanguageGenerator.Domain
 {
-    using Newtonsoft.Json;
-
     /// <summary>
     /// Actual translation results.
     /// </summary>

--- a/src/DocLanguageTranslator/Domain/TranslationResults.cs
+++ b/src/DocLanguageTranslator/Domain/TranslationResults.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using Newtonsoft.Json;
 
 namespace DocFXLanguageGenerator.Domain
 {
-    using Newtonsoft.Json;
-
     /// <summary>
     /// The translation result from the call to Azure Cognitive Service API.
     /// </summary>

--- a/src/DocLanguageTranslator/Helpers/MessageHelper.cs
+++ b/src/DocLanguageTranslator/Helpers/MessageHelper.cs
@@ -1,11 +1,9 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using DocFXLanguageGenerator.Domain;
 
 namespace DocFXLanguageGenerator.Helpers
 {
-    using System;
-    using DocFXLanguageGenerator.Domain;
-
     /// <summary>
     /// Helper methods to write messages to the console.
     /// </summary>

--- a/src/DocLanguageTranslator/MarkdownTransformRenderer.cs
+++ b/src/DocLanguageTranslator/MarkdownTransformRenderer.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using Markdig.Renderers;
+using Markdig.Syntax;
 
 namespace DocFXLanguageGenerator
 {
-    using System.IO;
-    using Markdig.Renderers;
-    using Markdig.Syntax;
-
     /// <summary>
     /// A Text Renderer MArkdown class used to replace the original text with the translated text.
     /// </summary>

--- a/src/DocLanguageTranslator/Program.cs
+++ b/src/DocLanguageTranslator/Program.cs
@@ -1,23 +1,16 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using CommandLine;
+using DocFXLanguageGenerator.Domain;
+using DocFXLanguageGenerator.Helpers;
+using Markdig;
+using Newtonsoft.Json;
 
 namespace DocFXLanguageGenerator
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.IO;
-    using System.Linq;
-    using System.Net.Http;
-    using System.Text;
-    using System.Text.RegularExpressions;
-    using System.Threading.Tasks;
-    using CommandLine;
-    using DocFXLanguageGenerator.Domain;
-    using DocFXLanguageGenerator.Helpers;
-    using Markdig;
-    using Newtonsoft.Json;
-
     /// <summary>
     /// The core program.
     /// </summary>

--- a/src/DocLanguageTranslator/ReplacementRenderer.cs
+++ b/src/DocLanguageTranslator/ReplacementRenderer.cs
@@ -1,13 +1,10 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+using Markdig.Renderers;
+using Markdig.Syntax.Inlines;
 
 namespace DocFXLanguageGenerator
 {
-    using System;
-    using System.IO;
-    using Markdig.Renderers;
-    using Markdig.Syntax.Inlines;
-
     /// <summary>
     /// Replacement Renderer will allow to replace one text by another.
     /// </summary>


### PR DESCRIPTION
* Usings outside namespace
* Proper formatting of new()
* Tuple variables need camel casing