### PR TITLE
DocFxTocGenerator: added camelCase option

### DIFF
--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/ConfigFilesServiceTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/ConfigFilesServiceTests.cs
@@ -27,7 +27,7 @@ public class ConfigFilesServiceTests
     public void OrderList_GetExistingFile_ShouldBeValid()
     {
         // arrange
-        ConfigFilesService service = new(_fileService, _logger);
+        ConfigFilesService service = new(camelCasing: false, _fileService, _logger);
 
         // act
         var mockfile = _fileService.GetOrderFile();
@@ -53,7 +53,7 @@ public class ConfigFilesServiceTests
     public void OrderList_GetNonExisting_ShouldBeInitialized()
     {
         // arrange
-        ConfigFilesService service = new(_fileService, _logger);
+        ConfigFilesService service = new(camelCasing: false, _fileService, _logger);
         string folder = _fileService.AddFolder("temp");
 
         // act
@@ -74,7 +74,7 @@ public class ConfigFilesServiceTests
     public void OrderList_GetExistingWithIndex_ShouldBeOrderedCorrectly()
     {
         // arrange
-        ConfigFilesService service = new(_fileService, _logger);
+        ConfigFilesService service = new(camelCasing: false, _fileService, _logger);
         string folder = _fileService.AddFolder("temp");
         _fileService.AddFile(folder, ".order",
 @"readme
@@ -100,7 +100,7 @@ number-one");
     public void IgnoreList_GetExistingFile_ShouldBeValid()
     {
         // arrange
-        ConfigFilesService service = new(_fileService, _logger);
+        ConfigFilesService service = new(camelCasing: false, _fileService, _logger);
 
         // act
         var mockfile = _fileService.GetIgnoreFile();
@@ -123,7 +123,7 @@ number-one");
     public void IgnoreList_GetNonExisting_ShouldBeInitialized()
     {
         // arrange
-        ConfigFilesService service = new(_fileService, _logger);
+        ConfigFilesService service = new(camelCasing: false, _fileService, _logger);
         string folder = _fileService.AddFolder("temp");
 
         // act
@@ -140,7 +140,7 @@ number-one");
     public void OverrideList_GetExistingFile_ShouldBeValid()
     {
         // arrange
-        ConfigFilesService service = new(_fileService, _logger);
+        ConfigFilesService service = new(camelCasing: false, _fileService, _logger);
 
         // act
         var mockfile = _fileService.GetOverrideFile();
@@ -165,7 +165,7 @@ number-one");
     public void OverrideList_GetNonExisting_ShouldBeInitialized()
     {
         // arrange
-        ConfigFilesService service = new(_fileService, _logger);
+        ConfigFilesService service = new(camelCasing: false, _fileService, _logger);
         string folder = _fileService.AddFolder("temp");
 
         // act

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/ContentInventoryActionTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/ContentInventoryActionTests.cs
@@ -27,7 +27,7 @@ public class ContentInventoryActionTests
     public async void Run_WithoutSettings()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
 
         // act
         ReturnCode ret = await action.RunAsync();
@@ -97,7 +97,7 @@ public class ContentInventoryActionTests
     public async void Run_WithOrderOnly()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
 
         // act
         ReturnCode ret = await action.RunAsync();
@@ -167,7 +167,7 @@ public class ContentInventoryActionTests
     public async void Run_WithIgnoreOnly()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: false, useIgnore: true, useOverride: false, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: false, useIgnore: true, useOverride: false, camelCasing: false, _fileService, _logger);
 
         // act
         ReturnCode ret = await action.RunAsync();
@@ -236,7 +236,7 @@ public class ContentInventoryActionTests
     public async void Run_WithOverrideOnly()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         ReturnCode ret = await action.RunAsync();
@@ -305,7 +305,7 @@ public class ContentInventoryActionTests
     public async void Run_WithNonExistingFolder_ReturnsError()
     {
         // arrange
-        ContentInventoryAction action = new("x:\\Non-existing\\docs", useOrder: false, useIgnore: false, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new("x:\\Non-existing\\docs", useOrder: false, useIgnore: false, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         ReturnCode ret = await action.RunAsync();
@@ -322,7 +322,7 @@ public class ContentInventoryActionTests
         // arrange
         _fileService.Files.Clear();
         _fileService.AddFolder("x:\\Non-existing\\docs");
-        ContentInventoryAction action = new("x:\\Non-existing\\docs", useOrder: false, useIgnore: false, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new("x:\\Non-existing\\docs", useOrder: false, useIgnore: false, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         ReturnCode ret = await action.RunAsync();

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/EnsureIndexActionTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/EnsureIndexActionTests.cs
@@ -28,10 +28,10 @@ public class EnsureIndecxActionTests
     public async void Run_NoIndex()
     {
         // arrange
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, _fileService, _logger);
+        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, camelCasing: false, _fileService, _logger);
         int originalCount = _fileService.Files.Count;
 
         // act
@@ -46,10 +46,10 @@ public class EnsureIndecxActionTests
     public async void Run_GenerateForFoldersWithoutDefaults()
     {
         // arrange
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.NoDefault, _fileService, _logger);
+        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.NoDefault, camelCasing: false, _fileService, _logger);
         int originalCount = _fileService.Files.Count;
 
         // act
@@ -81,10 +81,10 @@ public class EnsureIndecxActionTests
     public async void Run_GenerateForFoldersWithoutDefaultsAndMutlipleFiles()
     {
         // arrange
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.NoDefaultMulti, _fileService, _logger);
+        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.NoDefaultMulti, camelCasing: false, _fileService, _logger);
         int originalCount = _fileService.Files.Count;
 
         // act
@@ -112,10 +112,10 @@ public class EnsureIndecxActionTests
     public async void Run_GenerateForEmptyFolders()
     {
         // arrange
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.EmptyFolders, _fileService, _logger);
+        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.EmptyFolders, camelCasing: false, _fileService, _logger);
         int originalCount = _fileService.Files.Count;
 
         // act
@@ -139,10 +139,10 @@ public class EnsureIndecxActionTests
     public async void Run_GenerateForFoldersWithoutIndex()
     {
         // arrange
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.NotExists, _fileService, _logger);
+        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.NotExists, camelCasing: false, _fileService, _logger);
         int originalCount = _fileService.Files.Count;
 
         // act
@@ -179,10 +179,10 @@ public class EnsureIndecxActionTests
     public async void Run_GenerateForFoldersWithoutIndexAndMultipleFiles()
     {
         // arrange
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.NotExistMulti, _fileService, _logger);
+        EnsureIndexAction action = new(content.RootFolder!, Index.IndexGenerationStrategy.NotExistMulti, camelCasing: false, _fileService, _logger);
         int originalCount = _fileService.Files.Count;
 
         // act
@@ -212,7 +212,7 @@ public class EnsureIndecxActionTests
     public async void Run_ErrorWithNullRoot()
     {
         // arrange
-        EnsureIndexAction action = new(null, Index.IndexGenerationStrategy.Never, _fileService, _logger);
+        EnsureIndexAction action = new(null, Index.IndexGenerationStrategy.Never, camelCasing: false, _fileService, _logger);
 
         // act
         ReturnCode ret = await action.RunAsync();

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/FileInfoServiceTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/FileInfoServiceTests.cs
@@ -24,19 +24,20 @@ public class FileInfoServiceTests
     }
 
     [Theory]
-    [InlineData("file.md", "File.md")]
-    [InlineData("something", "Something")]
-    [InlineData("another-thing", "Another thing")]
-    [InlineData("another--thing--with--double--dashes", "Another thing with double dashes")]
-    [InlineData("a-file-with-strange-characters-\\/:*-END", "A file with strange characters END")]
-    [InlineData("another file with áåàæßšűç Unicode", "Another file with áåàæßšűç Unicode")]
-    public void TitleCase_ShouldBeValid(string input, string expected)
+    [InlineData("file.md", "File.md", false)]
+    [InlineData("something", "Something", false)]
+    [InlineData("another-thing", "Another thing", false)]
+    [InlineData("another--thing--with--double--dashes", "Another thing with double dashes", false)]
+    [InlineData("a-file-with-strange-characters-\\/:*-END", "A file with strange characters END", false)]
+    [InlineData("another file with áåàæßšűç Unicode", "Another file with áåàæßšűç Unicode", false)]
+    [InlineData("Test of camelCasing.", "test of camelCasing.", true)]
+    public void TitleCase_ShouldBeValid(string input, string expected, bool camelCasing)
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing, _fileService, _logger);
 
         // act
-        string output = service.ToTitleCase(input);
+        string output = service.ToTitleCase(input, camelCasing);
 
         // assert
         output.Should().Be(expected);
@@ -46,7 +47,7 @@ public class FileInfoServiceTests
     public void CreateFileData_Defaults_ShouldCreateValidItem()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
         string foldername = "MockFolder";
         string filename = "mock-file.md";
         FolderData? folder = new()
@@ -73,7 +74,7 @@ public class FileInfoServiceTests
     public void CreateFileData_WithOrder_ShouldCreateValidItem()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
         string foldername = "MockFolder";
         string filename = "mock-file.md";
         FolderData? folder = new()
@@ -101,7 +102,7 @@ public class FileInfoServiceTests
     public void CreateFileData_WithOverride_ShouldCreateValidItem()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
         string foldername = "MockFolder";
         string filename = "mock-file.md";
         string overridename = "Override name for this file.";
@@ -130,20 +131,33 @@ public class FileInfoServiceTests
     public void GetFileDisplayName_Markdown_GetValidH1()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
 
         // act
-        var title = service.GetFileDisplayName(_fileService.GetFullPath("continents/europe/germany/munchen.md"));
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("continents/europe/germany/munchen.md"), false);
 
         // assert
         title.Should().Be("München");
     }
 
     [Fact]
+    public void GetFileDisplayName_Markdown_GetValidH1_CamelCase()
+    {
+        // arrange
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
+
+        // act
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("continents/europe/germany/munchen.md"), true);
+
+        // assert
+        title.Should().Be("münchen");
+    }
+
+    [Fact]
     public void GetFileDisplayName_Markdown_GetValidH1_Complex()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
 
         string folder = _fileService.AddFolder("temp");
         _fileService.AddFile(folder, "temp-markdown.md", string.Empty
@@ -151,7 +165,7 @@ public class FileInfoServiceTests
             .AddParagraphs(3));
 
         // act
-        var title = service.GetFileDisplayName(_fileService.GetFullPath("temp/temp-markdown.md"));
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("temp/temp-markdown.md"), false);
 
         // cleanup
         _fileService.Delete("temp/temp-markdown.md");
@@ -162,16 +176,38 @@ public class FileInfoServiceTests
     }
 
     [Fact]
+    public void GetFileDisplayName_Markdown_GetValidH1_Complex_CamelCase()
+    {
+        // arrange
+        FileInfoService service = new(camelCasing: true, _fileService, _logger);
+
+        string folder = _fileService.AddFolder("temp");
+        _fileService.AddFile(folder, "temp-markdown.md", string.Empty
+            .AddHeading("`This is a header with quotes`", 1)
+            .AddParagraphs(3));
+
+        // act
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("temp/temp-markdown.md"), true);
+
+        // cleanup
+        _fileService.Delete("temp/temp-markdown.md");
+        _fileService.Delete(folder);
+
+        // assert
+        title.Should().Be("this is a header with quotes");
+    }
+
+    [Fact]
     public void GetFileDisplayName_Markdown_GetFileNameWhenNoH1()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
 
         string folder = _fileService.AddFolder("temp");
         _fileService.AddFile(folder, "temp-markdown.md", "A markdown file without H1");
 
         // act
-        var title = service.GetFileDisplayName(_fileService.GetFullPath("temp/temp-markdown.md"));
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("temp/temp-markdown.md"), false);
 
         // cleanup
         _fileService.Delete("temp/temp-markdown.md");
@@ -182,55 +218,114 @@ public class FileInfoServiceTests
     }
 
     [Fact]
+    public void GetFileDisplayName_Markdown_GetFileNameWhenNoH1_CamelCase()
+    {
+        // arrange
+        FileInfoService service = new(camelCasing: true, _fileService, _logger);
+
+        string folder = _fileService.AddFolder("temp");
+        _fileService.AddFile(folder, "temp-markdown.md", "A markdown file without H1");
+
+        // act
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("temp/temp-markdown.md"), true);
+
+        // cleanup
+        _fileService.Delete("temp/temp-markdown.md");
+        _fileService.Delete(folder);
+
+        // assert
+        title.Should().Be("temp markdown");
+    }
+
+    [Fact]
     public void GetFileDisplayName_NonExisting_ShouldNotCrash()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
 
         // act
-        var title = service.GetFileDisplayName("non-existing/test.md");
+        var title = service.GetFileDisplayName("non-existing/test.md", false);
 
         // assert
         title.Should().Be("Test");
     }
 
     [Fact]
+    public void GetFileDisplayName_NonExisting_ShouldNotCrash_CamelCase()
+    {
+        // arrange
+        FileInfoService service = new(camelCasing: true, _fileService, _logger);
+
+        // act
+        var title = service.GetFileDisplayName("non-existing/test.md", true);
+
+        // assert
+        title.Should().Be("test");
+    }
+
+    [Fact]
     public void GetFileDisplayName_Swagger_GetValidH1()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
 
         // act
-        var title = service.GetFileDisplayName(_fileService.GetFullPath("software/apis/test-api/test-api.swagger.json"));
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("software/apis/test-api/test-api.swagger.json"), false);
 
         // assert
         title.Should().Be("Feature.proto 1.0.0.3145");
     }
 
     [Fact]
+    public void GetFileDisplayName_Swagger_GetValidH1_CamelCase()
+    {
+        // arrange
+        FileInfoService service = new(camelCasing: true, _fileService, _logger);
+
+        // act
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("software/apis/test-api/test-api.swagger.json"), true);
+
+        // assert
+        title.Should().Be("feature.proto 1.0.0.3145");
+    }
+
+    [Fact]
     public void GetFileDisplayName_Swagger_GetValidH1_MissingVersion()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
 
         // act
-        var title = service.GetFileDisplayName(_fileService.GetFullPath("software/apis/test-plain-api/swagger.json"));
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("software/apis/test-plain-api/swagger.json"), false);
 
         // assert
         title.Should().Be("SimpleApi.Test");
     }
 
     [Fact]
+    public void GetFileDisplayName_Swagger_GetValidH1_MissingVersion_CamelCase()
+    {
+        // arrange
+        FileInfoService service = new(camelCasing: true, _fileService, _logger);
+
+        // act
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("software/apis/test-plain-api/swagger.json"), true);
+
+        // assert
+        title.Should().Be("simpleApi.Test");
+    }
+
+    [Fact]
     public void GetFileDisplayName_Swagger_GetFileNameWhenInvalidJson()
     {
         // arrange
-        FileInfoService service = new(_fileService, _logger);
+        FileInfoService service = new(camelCasing: false, _fileService, _logger);
 
         string folder = _fileService.AddFolder("temp");
         _fileService.AddFile(folder, "temp.swagger.json", "This is invalid content for a json file.");
 
         // act
-        var title = service.GetFileDisplayName(_fileService.GetFullPath("temp/temp.swagger.json"));
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("temp/temp.swagger.json"), false);
 
         // cleanup
         _fileService.Delete("temp/temp.swagger.json");
@@ -238,5 +333,25 @@ public class FileInfoServiceTests
 
         // asserts
         title.Should().Be("Temp");
+    }
+
+    [Fact]
+    public void GetFileDisplayName_Swagger_GetFileNameWhenInvalidJson_CamelCase()
+    {
+        // arrange
+        FileInfoService service = new(camelCasing: true, _fileService, _logger);
+
+        string folder = _fileService.AddFolder("temp");
+        _fileService.AddFile(folder, "temp.swagger.json", "This is invalid content for a json file.");
+
+        // act
+        var title = service.GetFileDisplayName(_fileService.GetFullPath("temp/temp.swagger.json"), true);
+
+        // cleanup
+        _fileService.Delete("temp/temp.swagger.json");
+        _fileService.Delete(folder);
+
+        // asserts
+        title.Should().Be("temp");
     }
 }

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/GenerateTocActionTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/GenerateTocActionTests.cs
@@ -28,10 +28,10 @@ public class GenerateTocActionTests
     public async void Run_SimpleToc()
     {
         // arrange
-        ContentInventoryAction content = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, _fileService, _logger);
+        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, camelCasing: false, _fileService, _logger);
         await index.RunAsync();
 
         GenerateTocAction action = new(
@@ -90,10 +90,10 @@ public class GenerateTocActionTests
         _fileService.AddFile(folder, "bmw.md", string.Empty.AddHeading("BMW", 1).AddParagraphs(1));
         _fileService.AddFile(folder, "README.md", string.Empty.AddHeading("Cars", 1).AddParagraphs(1));
 
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, _fileService, _logger);
+        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, camelCasing: false, _fileService, _logger);
         await index.RunAsync();
 
         GenerateTocAction action = new(
@@ -182,13 +182,13 @@ public class GenerateTocActionTests
         // assert
         ret.Should().Be(ReturnCode.Normal);
 
-        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml")).Replace("\r", string.Empty);
+        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml"));
         toc.Should().Be(rootExpected);
 
-        toc = _fileService.ReadAllText(_fileService.GetFullPath("continents/toc.yml")).Replace("\r", string.Empty);
+        toc = _fileService.ReadAllText(_fileService.GetFullPath("continents/toc.yml"));
         toc.Should().Be(continentsExpected);
 
-        toc = _fileService.ReadAllText(_fileService.GetFullPath("vehicles/toc.yml")).Replace("\r", string.Empty);
+        toc = _fileService.ReadAllText(_fileService.GetFullPath("vehicles/toc.yml"));
         toc.Should().Be(vehiclesExpected);
     }
 
@@ -201,10 +201,10 @@ public class GenerateTocActionTests
         _fileService.AddFile(string.Empty, "file1.md", string.Empty.AddHeading("File 1", 1).AddParagraphs(1));
         _fileService.AddFile(string.Empty, "file2.md", string.Empty.AddHeading("File 2", 1).AddParagraphs(1));
 
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, _fileService, _logger);
+        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, camelCasing: false, _fileService, _logger);
         await index.RunAsync();
 
         GenerateTocAction action = new(
@@ -234,7 +234,7 @@ public class GenerateTocActionTests
         // assert
         ret.Should().Be(ReturnCode.Normal);
         _fileService.Files.Should().HaveCount(originalCount + 1);
-        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml")).Replace("\r", "");
+        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml"));
         toc.Should().Be(expected);
     }
 
@@ -247,10 +247,10 @@ public class GenerateTocActionTests
         var folder = _fileService.AddFolder("A");
         _fileService.AddFile(folder, "B.md", string.Empty.AddHeading("B doc", 1).AddParagraphs(1));
 
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.NotExists, _fileService, _logger);
+        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.NotExists, camelCasing: false, _fileService, _logger);
         await index.RunAsync();
 
         GenerateTocAction action = new(
@@ -281,7 +281,7 @@ public class GenerateTocActionTests
         // assert
         ret.Should().Be(ReturnCode.Normal);
         _fileService.Files.Should().HaveCount(originalCount + 1);
-        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml")).Replace("\r", "");
+        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml"));
         toc.Should().Be(expected);
     }
 
@@ -296,10 +296,10 @@ public class GenerateTocActionTests
         _fileService.AddFile(folder, "index.md", string.Empty.AddHeading("Index of A", 1).AddParagraphs(1));
         _fileService.AddFile(folder, "B.md", string.Empty.AddHeading("B doc", 1).AddParagraphs(1));
 
-        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, _fileService, _logger);
+        ContentInventoryAction content = new(_fileService.Root, useOrder: false, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
         await content.RunAsync();
 
-        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.NotExists, _fileService, _logger);
+        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.NotExists, camelCasing: false, _fileService, _logger);
         await index.RunAsync();
 
         GenerateTocAction action = new(
@@ -330,7 +330,7 @@ public class GenerateTocActionTests
         // assert
         ret.Should().Be(ReturnCode.Normal);
         _fileService.Files.Should().HaveCount(originalCount + 1);
-        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml")).Replace("\r", "");
+        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml"));
         toc.Should().Be(expected);
     }
 }

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/Helpers/MockFileService.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/Helpers/MockFileService.cs
@@ -736,7 +736,7 @@ rio-de-janeiro");
     {
         if (Files.TryGetValue(GetFullPath(path), out var content) && !string.IsNullOrEmpty(content))
         {
-            return content.Replace("'\r", string.Empty).Split('\n');
+            return content.Replace("\r", string.Empty).Split('\n');
         }
 
         return [];

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/IndexServiceTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/IndexServiceTests.cs
@@ -25,7 +25,7 @@ public class IndexServiceTests
     {
         _fileService.FillDemoSet();
         _logger = _mockLogger.Logger;
-        _config = new(_fileService, _logger);
+        _config = new(camelCasing: false, _fileService, _logger);
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class IndexServiceTests
     {
         // arrange
         IndexService service = new(_fileService, _logger);
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         await action.RunAsync();
@@ -58,7 +58,7 @@ public class IndexServiceTests
     {
         // arrange
         IndexService service = new(_fileService, _logger);
-        ContentInventoryAction action = new(_fileService.Root,  useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root,  useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         await action.RunAsync();
@@ -85,7 +85,7 @@ public class IndexServiceTests
     {
         // arrange
         IndexService service = new(_fileService, _logger);
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         await action.RunAsync();
@@ -112,7 +112,7 @@ public class IndexServiceTests
     {
         // arrange
         IndexService service = new(_fileService, _logger);
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         await action.RunAsync();

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/LiquidServiceTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/LiquidServiceTests.cs
@@ -25,7 +25,7 @@ public class LiquidServiceTests
     {
         _fileService.FillDemoSet();
         _logger = _mockLogger.Logger;
-        _config = new(_fileService, _logger);
+        _config = new(camelCasing: false, _fileService, _logger);
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class LiquidServiceTests
     {
         // arrange
         LiquidService service = new(_logger);
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         await action.RunAsync();
@@ -51,7 +51,7 @@ public class LiquidServiceTests
     {
         // arrange
         LiquidService service = new(_logger);
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         await action.RunAsync();
@@ -72,7 +72,7 @@ public class LiquidServiceTests
     {
         // arrange
         LiquidService service = new(_logger);
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         await action.RunAsync();
@@ -91,7 +91,7 @@ public class LiquidServiceTests
     {
         // arrange
         LiquidService service = new(_logger);
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
 
         // act
         await action.RunAsync();

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/TableOfContentsServiceTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/TableOfContentsServiceTests.cs
@@ -26,14 +26,14 @@ public class TableOfContentsServiceTests
     {
         _fileService.FillDemoSet();
         _logger = _mockLogger.Logger;
-        _config = new(_fileService, _logger);
+        _config = new(camelCasing: false, _fileService, _logger);
     }
 
     [Fact]
     public async Task GetTocItems_GetTocForFolderWithOrdering()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.All, _fileService, _logger);
         await action.RunAsync();
         FolderData? current = action!.RootFolder!.Find("continents/americas/brasil");
@@ -61,7 +61,7 @@ public class TableOfContentsServiceTests
     public async Task GetTocItems_GetTocForFolderWithIgnore()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.All, _fileService, _logger);
         await action.RunAsync();
         FolderData? current = action!.RootFolder!.Find("continents/americas/united-states");
@@ -90,7 +90,7 @@ public class TableOfContentsServiceTests
     public async Task GetTocItems_GetTocForFolderWithOverride()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.All, _fileService, _logger);
         await action.RunAsync();
         FolderData? current = action!.RootFolder!.Find("continents/americas/united-states/washington");
@@ -118,7 +118,7 @@ public class TableOfContentsServiceTests
     public async Task GetTocItems_GetTocFolderReferenceIndex()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.Index, TocOrderStrategy.All, _fileService, _logger);
         await action.RunAsync();
         FolderData? current = action!.RootFolder!.Find("deep-tree/level1");
@@ -144,7 +144,7 @@ public class TableOfContentsServiceTests
     public async Task GetTocItems_GetTocFolderReferenceReadme()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.IndexReadme, TocOrderStrategy.All, _fileService, _logger);
         await action.RunAsync();
         FolderData? current = action!.RootFolder!.Find("deep-tree/level1/level2/level3/level4");
@@ -170,7 +170,7 @@ public class TableOfContentsServiceTests
     public async Task GetTocItems_GetTocFolderReferenceFirst()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.First, TocOrderStrategy.All, _fileService, _logger);
         await action.RunAsync();
         FolderData? current = action!.RootFolder!.Find("continents/europe/netherlands");
@@ -197,7 +197,7 @@ public class TableOfContentsServiceTests
     public async Task GetTocItems_GetTocOrderingAll()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.All, _fileService, _logger);
         await action.RunAsync();
         FolderData? current = action!.RootFolder!.Find("continents");
@@ -225,7 +225,7 @@ public class TableOfContentsServiceTests
     public async Task GetTocItems_GetTocOrderingFoldersFirst()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.FoldersFirst, _fileService, _logger);
         await action.RunAsync();
         FolderData? current = action!.RootFolder!.Find("continents");
@@ -253,7 +253,7 @@ public class TableOfContentsServiceTests
     public async Task GetTocItems_GetTocOrderingFilesFirst()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.FilesFirst, _fileService, _logger);
         await action.RunAsync();
         FolderData? current = action!.RootFolder!.Find("continents");
@@ -281,7 +281,7 @@ public class TableOfContentsServiceTests
     public async Task SerializeTocItem_OneLevelOnly()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.FilesFirst, _fileService, _logger);
 
         using StringWriter sw = new StringWriter();
@@ -306,7 +306,7 @@ public class TableOfContentsServiceTests
         service.SerializeTocItem(writer, toc, maxDepth: 1);
 
         // assert
-        string output = sw.ToString().Replace("\r", "");
+        string output = sw.ToString();
         output.Should().Be(expected);
     }
 
@@ -314,7 +314,7 @@ public class TableOfContentsServiceTests
     public async Task SerializeTocItem_OneLevelOnly_WithStartPath()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.FilesFirst, _fileService, _logger);
 
         using StringWriter sw = new StringWriter();
@@ -340,7 +340,7 @@ public class TableOfContentsServiceTests
         service.SerializeTocItem(writer, toc, maxDepth: 1, startPath: rootPath);
 
         // assert
-        string output = sw.ToString().Replace("\r", "");
+        string output = sw.ToString();
         output.Should().Be(expected);
     }
 
@@ -348,7 +348,7 @@ public class TableOfContentsServiceTests
     public async Task SerializeTocItem_Hierarchy()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.FilesFirst, _fileService, _logger);
 
         using StringWriter sw = new StringWriter();
@@ -459,7 +459,126 @@ public class TableOfContentsServiceTests
         service.SerializeTocItem(writer, toc, maxDepth: 0);
 
         // assert
-        string output = sw.ToString().Replace("\r", "");
+        string output = sw.ToString();
+        output.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task SerializeTocItem_Hierarchy_CamelCase()
+    {
+        // arrange
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: true, _fileService, _logger);
+        TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.FilesFirst, _fileService, _logger);
+
+        using StringWriter sw = new StringWriter();
+        using IndentedTextWriter writer = new IndentedTextWriter(sw, "  ");
+
+        await action.RunAsync();
+        var toc = service.GetTocItemsForFolder(action.RootFolder!, 0);
+
+        #region expected output
+        string expected =
+@"- name: docs
+- name: main readme
+  href: README.md
+- name: continents
+  items:
+  - name: continents README
+    href: continents/README.md
+  - name: unmentioned Continents
+    href: continents/unmentioned-continents.md
+  - name: americas
+    items:
+    - name: the Americas
+      href: continents/americas/README.md
+    - name: brasil
+      items:
+      - name: sao Paulo
+        href: continents/americas/brasil/sao-paulo.md
+      - name: nova Friburgo
+        href: continents/americas/brasil/nova-friburgo.md
+      - name: rio de Janeiro
+        href: continents/americas/brasil/rio-de-janeiro.md
+    - name: united states
+      items:
+      - name: california
+        items:
+        - name: los Angeles
+          href: continents/americas/united-states/california/los-angeles.md
+        - name: san Diego
+          href: continents/americas/united-states/california/san-diego.md
+        - name: san Francisco
+          href: continents/americas/united-states/california/san-francisco.md
+      - name: new york
+        items:
+        - name: new York City
+          href: continents/americas/united-states/new-york/new-york-city.md
+      - name: washington
+        items:
+        - name: seattle
+          href: continents/americas/united-states/washington/seattle.md
+        - name: This is where the airport is - Tacoma Airport
+          href: continents/americas/united-states/washington/tacoma.md
+  - name: europe
+    items:
+    - name: europe
+      href: continents/europe/README.md
+    - name: germany
+      items:
+      - name: germany README
+        href: continents/europe/germany/README.md
+      - name: berlin
+        href: continents/europe/germany/berlin.md
+      - name: münchen
+        href: continents/europe/germany/munchen.md
+    - name: netherlands
+      items:
+      - name: noord holland
+        items:
+        - name: amsterdam
+          href: continents/europe/netherlands/noord-holland/amsterdam.md
+      - name: zuid holland
+        items:
+        - name: rotterdam
+          href: continents/europe/netherlands/zuid-holland/rotterdam.md
+        - name: the Hague
+          href: continents/europe/netherlands/zuid-holland/den-haag.md
+- name: deep tree
+  items:
+  - name: level1
+    items:
+    - name: level2
+      items:
+      - name: index of LEVEL 2
+        href: deep-tree/level1/level2/index.md
+      - name: level3
+        items:
+        - name: level4
+          items:
+          - name: level5
+            items:
+            - name: deep tree readme
+              href: deep-tree/level1/level2/level3/level4/level5/README.md
+- name: software
+  items:
+  - name: apis
+    items:
+    - name: test api
+      items:
+      - name: feature.proto 1.0.0.3145
+        href: software/apis/test-api/test-api.swagger.json
+    - name: test plain api
+      items:
+      - name: simpleApi.Test
+        href: software/apis/test-plain-api/swagger.json
+";
+        #endregion
+
+        // act
+        service.SerializeTocItem(writer, toc, maxDepth: 0);
+
+        // assert
+        string output = sw.ToString();
         output.Should().Be(expected);
     }
 
@@ -467,7 +586,7 @@ public class TableOfContentsServiceTests
     public async Task WriteTocFile_OneLevel()
     {
         // arrange
-        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, _fileService, _logger);
+        ContentInventoryAction action = new(_fileService.Root, useOrder: true, useIgnore: true, useOverride: true, camelCasing: false, _fileService, _logger);
         TableOfContentsService service = new(_fileService.Root, TocFolderReferenceStrategy.None, TocOrderStrategy.FilesFirst, _fileService, _logger);
 
         await action.RunAsync();
@@ -492,7 +611,7 @@ public class TableOfContentsServiceTests
         // assert
         string tocPath = Path.Combine(_fileService.Root, "toc.yml");
         _fileService.ExistsFileOrDirectory(tocPath).Should().BeTrue();
-        string output = _fileService.ReadAllText(tocPath).Replace("\r", "");
+        string output = _fileService.ReadAllText(tocPath);
         output.Should().Be(expected);
     }
 }

--- a/src/DocFxTocGenerator/DocFxTocGenerator/Actions/ContentInventoryAction.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/Actions/ContentInventoryAction.cs
@@ -19,6 +19,7 @@ public class ContentInventoryAction
     private readonly bool _useOrder;
     private readonly bool _useIgnore;
     private readonly bool _useOverride;
+    private readonly bool _camelCasing;
 
     private readonly IFileService? _fileService;
     private readonly ConfigFilesService _configService;
@@ -35,6 +36,7 @@ public class ContentInventoryAction
     /// <param name="useOrder">Use the .order configuration per directory.</param>
     /// <param name="useIgnore">Use the .ignore configuration per directory.</param>
     /// <param name="useOverride">Use the .override configuration per directory.</param>
+    /// <param name="camelCasing">Use camel casing for titles.</param>
     /// <param name="fileService">File service.</param>
     /// <param name="logger">Logger.</param>
     public ContentInventoryAction(
@@ -42,6 +44,7 @@ public class ContentInventoryAction
         bool useOrder,
         bool useIgnore,
         bool useOverride,
+        bool camelCasing,
         IFileService fileService,
         ILogger logger)
     {
@@ -50,11 +53,12 @@ public class ContentInventoryAction
         _useOrder = useOrder;
         _useIgnore = useIgnore;
         _useOverride = useOverride;
+        _camelCasing = camelCasing;
 
         _fileService = fileService;
         _logger = logger;
-        _configService = new(fileService, logger);
-        _fileDataService = new(fileService, logger);
+        _configService = new(camelCasing, fileService, logger);
+        _fileDataService = new(camelCasing, fileService, logger);
     }
 
     /// <summary>
@@ -112,7 +116,7 @@ public class ContentInventoryAction
         FolderData? folder = new()
         {
             Name = Path.GetFileName(dirpath),
-            DisplayName = _fileDataService.ToTitleCase(Path.GetFileNameWithoutExtension(dirpath)),
+            DisplayName = _fileDataService.ToTitleCase(Path.GetFileNameWithoutExtension(dirpath), _camelCasing),
             Path = dirpath.NormalizePath(),
             Parent = parent,
         };

--- a/src/DocFxTocGenerator/DocFxTocGenerator/Actions/EnsureIndexAction.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/Actions/EnsureIndexAction.cs
@@ -16,6 +16,7 @@ public class EnsureIndexAction
 {
     private readonly FolderData _rootFolder = new();
     private readonly IndexGenerationStrategy _indexGeneration;
+    private readonly bool _camelCasing;
 
     private readonly IFileService? _fileService;
     private readonly ILogger _logger;
@@ -27,21 +28,24 @@ public class EnsureIndexAction
     /// </summary>
     /// <param name="rootFolder">Root folder with the content.</param>
     /// <param name="indexGeneration">How to handle index generation.</param>
+    /// <param name="camelCasing">Use camel casing for titles.</param>
     /// <param name="fileService">File service.</param>
     /// <param name="logger">Logger.</param>
     public EnsureIndexAction(
         FolderData rootFolder,
         IndexGenerationStrategy indexGeneration,
+        bool camelCasing,
         IFileService fileService,
         ILogger logger)
     {
         _rootFolder = rootFolder;
         _indexGeneration = indexGeneration;
+        _camelCasing = camelCasing;
 
         _fileService = fileService;
         _logger = logger;
         _indexService = new(fileService, logger);
-        _fileDataService = new(fileService, logger);
+        _fileDataService = new(_camelCasing, fileService, logger);
     }
 
     /// <summary>

--- a/src/DocFxTocGenerator/DocFxTocGenerator/ConfigFiles/ConfigFilesService.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/ConfigFiles/ConfigFilesService.cs
@@ -12,6 +12,7 @@ namespace DocFxTocGenerator.ConfigFiles;
 /// </summary>
 public class ConfigFilesService
 {
+    private readonly bool _camelCasing;
     private readonly IFileService _fileService;
     private readonly ILogger _logger;
     private readonly FileInfoService _fileData;
@@ -19,14 +20,16 @@ public class ConfigFilesService
     /// <summary>
     /// Initializes a new instance of the <see cref="ConfigFilesService"/> class.
     /// </summary>
+    /// <param name="camelCasing">Use camel casing for titles.</param>
     /// <param name="fileService">File service.</param>
     /// <param name="logger">Logger.</param>
-    public ConfigFilesService(IFileService fileService, ILogger logger)
+    public ConfigFilesService(bool camelCasing, IFileService fileService, ILogger logger)
     {
+        _camelCasing = camelCasing;
         _fileService = fileService;
         _logger = logger;
 
-        _fileData = new(_fileService, _logger);
+        _fileData = new(_camelCasing, _fileService, _logger);
     }
 
     /// <summary>

--- a/src/DocFxTocGenerator/DocFxTocGenerator/README.md
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/README.md
@@ -43,6 +43,7 @@ Options:
   -m, --multitoc <multitoc>                                   Indicates how deep in the tree toc files should be
                                                               generated for those folders. A depth of 0 is the root
                                                               only (default behavior).
+  --camelCase                                                 Use camel casing for titles.
   --version                                                   Show version information
   -?, -h, --help                                              Show help and usage information
 ```
@@ -345,3 +346,10 @@ The `toc.yml` files in the sub-folders `continents` and `vehicles` will contain 
     href: cars/bmw.md
 ```
 
+## Camel case titles
+
+By default titles are changed to pascal casing, meaning that the first character is capitalized. With the option `--camelCase` all titles will be changed to camel casing, meaning that the first character is lower cased. Only exception are overrides from `.override` files.
+
+> [!NOTE]
+>
+> As this rule is applied to everything, it is also applied to titles coming from Swagger-files. If this is an issue, this can be corrected for that file using an `.override` file in that folder.


### PR DESCRIPTION
DocFxTocGenerator has a new option to output all titles in camelCase. If this option is not used, the already used PascalCase is used for titles. Only exception are titles coming from `.override` files.

Tests and documentation was modified for this change as well.

This closes #54 