### PR TITLE
DocFxTocGenerator: fixed folder override

### DIFF
--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/ContentInventoryActionTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/ContentInventoryActionTests.cs
@@ -264,7 +264,8 @@ public class ContentInventoryActionTests
         current.Folders[0].Name.Should().Be("germany");
         current.Folders[0].DisplayName.Should().Be("Germany");
         current.Folders[1].Name.Should().Be("netherlands");
-        current.Folders[1].DisplayName.Should().Be("Netherlands");
+        // here is a folder title from .override 
+        current.Folders[1].DisplayName.Should().Be("The Netherlands");
         current.FileCount.Should().Be(1);
         current.Files[0].Name.Should().Be("README.md");
         current.Files[0].DisplayName.Should().Be($"Europe");

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/Helpers/MockFileService.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/Helpers/MockFileService.cs
@@ -101,6 +101,8 @@ rio-de-janeiro");
         AddFile(folder, "README.md", string.Empty
             .AddHeading("Europe", 1)
             .AddParagraphs(1));
+        AddFile(folder, ".override",
+@"netherlands;The Netherlands");
 
         folder = AddFolder("continents/europe/germany");
         AddFile(folder, "README.md", string.Empty

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/TableOfContentsServiceTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/TableOfContentsServiceTests.cs
@@ -183,7 +183,8 @@ public class TableOfContentsServiceTests
         toc.IsFolder.Should().BeTrue();
         toc.Depth.Should().Be(5);
         toc.Base.Should().Be(current);
-        toc.Name.Should().Be("Netherlands");
+        // override name
+        toc.Name.Should().Be("The Netherlands");
         toc.Sequence.Should().Be(current!.Sequence);
         toc.Href.Should().BeNull();
 
@@ -412,7 +413,7 @@ public class TableOfContentsServiceTests
         href: continents/europe/germany/berlin.md
       - name: München
         href: continents/europe/germany/munchen.md
-    - name: Netherlands
+    - name: The Netherlands
       items:
       - name: Noord holland
         items:
@@ -531,7 +532,7 @@ public class TableOfContentsServiceTests
         href: continents/europe/germany/berlin.md
       - name: münchen
         href: continents/europe/germany/munchen.md
-    - name: netherlands
+    - name: The Netherlands
       items:
       - name: noord holland
         items:

--- a/src/DocFxTocGenerator/DocFxTocGenerator/Actions/ContentInventoryAction.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/Actions/ContentInventoryAction.cs
@@ -121,6 +121,15 @@ public class ContentInventoryAction
             Parent = parent,
         };
 
+        if (parent != null)
+        {
+            // see if we have an override for the folder name
+            if (parent.OverrideList.TryGetValue(folder.Name, out string? name))
+            {
+                folder.DisplayName = name;
+            }
+        }
+
         // read config files
         if (_useOrder)
         {

--- a/src/DocFxTocGenerator/DocFxTocGenerator/Program.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/Program.cs
@@ -35,7 +35,7 @@ var sequenceOption = new Option<bool>(
 sequenceOption.AddAlias("-s");
 var overrideOption = new Option<bool>(
     name: "--override",
-    description: "Use .override files per folder to define title overrides for files. Format of the file is filename without extension followed by a semi-column followed by the custom title per line.");
+    description: "Use .override files per folder to define title overrides for files and folders. Format of the file is filename without extension or directory name followed by a semi-column followed by the custom title per line.");
 overrideOption.AddAlias("-r");
 var ignoreOption = new Option<bool>(
     name: "--ignore",

--- a/src/DocFxTocGenerator/DocFxTocGenerator/README.md
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/README.md
@@ -16,9 +16,9 @@ Options:
                                                               files and directories. Format of the file is filename
                                                               without extension per line.
   -r, --override                                              Use .override files per folder to define title overrides
-                                                              for files. Format of the file is filename without
-                                                              extension followed by a semi-column followed by the
-                                                              custom title per line.
+                                                              for files and folders. Format of the file is filename
+                                                              without extension or directory name followed by a
+                                                              semi-column followed by the custom title per line.
   -g, --ignore                                                Use .ignore files per folder to ignore directories.
                                                               Format of the file is directory name per line.
   --indexing                                                  When to generated an index.md for a folder.
@@ -73,7 +73,7 @@ For directories the name of the directory is used by default, where the first ch
 
 For markdown files the first level-1 heading is taken as title. For swagger files the title and version are taken as title. On error the file name without extension is taken and processed the same way as the name of a directory.
 
-The `.override` setting file can be used to override this behavior. See [Defining title overrides with `.override`](#defining_title_overrides_with__override).
+The `.override` setting file can be used to override this behavior. See [Defining title overrides with `.override`](#defining-title-overrides-with-override).
 
 ## Folder settings
 
@@ -108,7 +108,7 @@ It only applies to the folder it's in, not for other subfolders under that folde
 
 ### Defining title overrides with `.override`
 
-If the `-r | --override` parameter is provided, the tool will inspect folders if a `.override` file exists and use that for overrides of file titles as they will show in the generated `toc.yml`. The `.override` file is a list of file- and/or directory-names, *case-sensitive* without file extensions, followed by a semi-column, followed by the title to use.
+If the `-r | --override` parameter is provided, the tool will inspect folders if a `.override` file exists and use that for overrides of file or directory titles as they will show in the generated `toc.yml`. The `.override` file is a list of file- and/or directory-names, *case-sensitive* without file extensions, followed by a semi-column, followed by the title to use.
 
 For example, if the folder name is `introduction`, the default behavior will be to create the name `Introduction`. If you want to call it `To start with`, you can use overrides, like in the following example:
 
@@ -117,7 +117,7 @@ introduction;To start with
 working-agreements;All working agreements of all teams
 ```
 
-If there are files or directories which are not in the .order file, they will be alphabetically ordered on the title and added after the ordered entries. The title for an MD-file is taken from the H1-header in the file. The title for a directory is the directory-name, but cleanup from special characters and the first character in capitals.
+The title for an MD-file is taken from the H1-header in the file. The title for a directory is the directory-name, but cleanup from special characters and the first character in capitals.
 
 ## Automatic generating `index.md` files
 


### PR DESCRIPTION
Was not implemented, now it is. So this closes #75