### PR TITLE
DocFxTocGenerator: Fixed override for folders to be used over index or readme

### DIFF
--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/Helpers/MockFileService.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/Helpers/MockFileService.cs
@@ -131,6 +131,8 @@ rio-de-janeiro");
 
         folder = AddFolder("deep-tree");
         folder = AddFolder("deep-tree/level1");
+        AddFile(folder, ".override",
+@"level2;The Second Level");
         folder = AddFolder("deep-tree/level1/level2");
         AddFile(folder, "index.md", string.Empty
             .AddHeading("Index of LEVEL 2", 1)

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/TableOfContentsServiceTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/TableOfContentsServiceTests.cs
@@ -136,7 +136,7 @@ public class TableOfContentsServiceTests
         toc.Href.Should().BeNull();
 
         toc.Items.Count.Should().Be(1);
-        toc.Items[0].Name.Should().Be("Index of LEVEL 2");
+        toc.Items[0].Name.Should().Be("The Second Level");
         toc.Items[0].Href.Should().Be("deep-tree/level1/level2/index.md");
     }
 
@@ -429,7 +429,7 @@ public class TableOfContentsServiceTests
   items:
   - name: Level1
     items:
-    - name: Level2
+    - name: The Second Level
       items:
       - name: Index of LEVEL 2
         href: deep-tree/level1/level2/index.md
@@ -548,7 +548,7 @@ public class TableOfContentsServiceTests
   items:
   - name: level1
     items:
-    - name: level2
+    - name: The Second Level
       items:
       - name: index of LEVEL 2
         href: deep-tree/level1/level2/index.md

--- a/src/DocFxTocGenerator/DocFxTocGenerator/Actions/ContentInventoryAction.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/Actions/ContentInventoryAction.cs
@@ -127,6 +127,7 @@ public class ContentInventoryAction
             if (parent.OverrideList.TryGetValue(folder.Name, out string? name))
             {
                 folder.DisplayName = name;
+                folder.IsDisplayNameOverride = true;
             }
         }
 

--- a/src/DocFxTocGenerator/DocFxTocGenerator/FileService/FileInfoService.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/FileService/FileInfoService.cs
@@ -73,6 +73,7 @@ public class FileInfoService
         {
             // override the display name
             filedata.DisplayName = name;
+            filedata.IsDisplayNameOverride = true;
         }
         else
         {

--- a/src/DocFxTocGenerator/DocFxTocGenerator/FileService/FolderFileBase.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/FileService/FolderFileBase.cs
@@ -28,6 +28,12 @@ public record FolderFileBase
     public string DisplayName { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets a value indicating whether the display name is coming from the .override.
+    /// This should always be the preference then.
+    /// </summary>
+    public bool IsDisplayNameOverride { get; set; }
+
+    /// <summary>
     /// Gets or sets the sequence value of this item.
     /// </summary>
     public int Sequence { get; set; } = int.MaxValue;

--- a/src/DocFxTocGenerator/DocFxTocGenerator/TableOfContents/TableOfContentsService.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/TableOfContents/TableOfContentsService.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 using System.CodeDom.Compiler;
+using System.Xml.Linq;
 using DocFxTocGenerator.FileService;
 using Microsoft.Extensions.Logging;
 
@@ -61,6 +62,13 @@ public class TableOfContentsService
             Href = folderEntry?.RelativePath!,
             Base = folder,
         };
+
+        // we took one of the defaults, but if the parent has an override for this folder
+        // the override must take preference. (fixing issue #77)
+        if (folder.IsDisplayNameOverride)
+        {
+            tocItem.Name = folder.DisplayName;
+        }
 
         // first add all sub folders
         foreach (var subfolder in folder.Folders)


### PR DESCRIPTION
Introduced a bool to track if we have an override of the DisplayName. For folders we use this to make sure we're not taking the title from the Index or ReadMe when indicated by the --folderRef. Override always must take preference.
Also added a test for this issue and modified others because of this improved behavior.

This closes #77 