### PR TITLE
DocLinkChecker: Normalize-path on heading validation

### DIFF
--- a/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
@@ -18,6 +18,7 @@
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using Xunit.Abstractions;
 
     public class HyperlinkTests
@@ -51,6 +52,27 @@
             _console = GetMockedConsoleLogger();
 
             _serviceProvider = GetServiceProviderWithCheckerHttpClient(_client, _config);
+        }
+
+        [Fact]
+        public async Task Issue81_ValidateLinkWithTopicOnWindows()
+        {
+            // Arrange
+            _config.DocumentationFiles.SourceFolder = _fileServiceMock.Root;
+            string source = $"{_fileServiceMock.Root}\\general\\another-sample.md";
+
+            LinkValidatorService service = new LinkValidatorService(_serviceProvider, _config, _fileService, _console);
+            service.Headings.Add(new(source, 99, 1, "Third.1 Header", "third-1-header"));
+
+            //Act
+            int line = 432;
+            int column = 771;
+
+            Hyperlink link = new Hyperlink($"{_fileServiceMock.Root}\\index.md", line, column, $"./general/another-sample.md#third-1-header");
+            await service.VerifyHyperlink(link);
+
+            // Assert
+            service.Errors.Should().BeEmpty();
         }
 
         [Fact]

--- a/src/DocLinkChecker/DocLinkChecker/Services/LinkValidatorService.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Services/LinkValidatorService.cs
@@ -344,19 +344,9 @@ namespace DocLinkChecker.Services
             {
                 // validate if heading exists in file
                 if (Headings
-                    .FirstOrDefault(x => string.Compare(hyperlink.UrlFullPath, x.FilePath, true) == 0 &&
+                    .FirstOrDefault(x => string.Compare(hyperlink.UrlFullPath.NormalizePath(), x.FilePath.NormalizePath(), true) == 0 &&
                                     x.Id == hyperlink.UrlTopic) == null)
                 {
-                    var hs = Headings
-                        .Where(x => string.Compare(hyperlink.UrlFullPath, x.FilePath, true) == 0)
-                        .OrderBy(x => x.Id)
-                        .ToList();
-                    Debug.WriteLine($"====== FOR {hyperlink.UrlFullPath} [{hyperlink.UrlTopic}] in {hyperlink.FilePath} {hyperlink.Line}:{hyperlink.Column} WE HAVE THESE OPTIONS:");
-                    foreach (var h in hs)
-                    {
-                        Debug.WriteLine($"{h.Id}");
-                    }
-
                     // url references a path outside of the document root
                     _errors.Enqueue(
                         new MarkdownError(


### PR DESCRIPTION
Handles different path separators in Linux and Windows, where Windows can have \ and /. Added path normalization on comparison. Also added test for this issue.

Solves #81 