### PR TITLE
DocFxTocGenerator: fixed ordering of folders

### DIFF
--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/GenerateTocActionTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/GenerateTocActionTests.cs
@@ -384,4 +384,312 @@ public class GenerateTocActionTests
         string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml"));
         toc.Should().Be(expected);
     }
+
+    [Fact]
+    public async Task Run_Issue_86_OrderingAll()
+    {
+        // arrange
+        Issue_86_Setup();
+
+        ContentInventoryAction content = new(_fileService.Root, useOrder: true, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
+        await content.RunAsync();
+
+        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, camelCasing: false, _fileService, _logger);
+        await index.RunAsync();
+
+        GenerateTocAction action = new(
+            _fileService.Root,
+            content.RootFolder!,
+            folderReferenceStrategy: TocFolderReferenceStrategy.None,
+            orderStrategy: TocOrderStrategy.All,     // this is distinctive for this test
+            maxDepth: 0,
+            _fileService,
+            _logger);
+
+        int originalCount = _fileService.Files.Count();
+
+        string expected =
+@"# This is an automatically generated file
+- name: Docs
+- name: FilesOnly
+  items:
+  - name: C Document
+    href: FilesOnly/C.md
+  - name: B Document
+    href: FilesOnly/B.md
+  - name: A document
+    href: FilesOnly/A.md
+- name: FoldersAndFiles
+  items:
+  - name: BB
+    items:
+    - name: BB Document
+      href: FoldersAndFiles/BB/README.md
+  - name: B Document
+    href: FoldersAndFiles/B.md
+  - name: AA
+    items:
+    - name: AA Document
+      href: FoldersAndFiles/AA/README.md
+  - name: A document
+    href: FoldersAndFiles/A.md
+  - name: CC
+    items:
+    - name: CC Document
+      href: FoldersAndFiles/CC/README.md
+  - name: C Document
+    href: FoldersAndFiles/C.md
+- name: FoldersOnly
+  items:
+  - name: CC
+    items:
+    - name: CC Document
+      href: FoldersOnly/CC/README.md
+  - name: BB
+    items:
+    - name: BB Document
+      href: FoldersOnly/BB/README.md
+  - name: AA
+    items:
+    - name: AA Document
+      href: FoldersOnly/AA/README.md
+".NormalizeContent();
+
+        // act
+        ReturnCode ret = await action.RunAsync();
+
+        // assert
+        ret.Should().Be(ReturnCode.Normal);
+        _fileService.Files.Should().HaveCount(originalCount + 1);
+        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml"));
+        toc.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Run_Issue_86_OrderingFilesFirst()
+    {
+        // arrange
+        Issue_86_Setup();
+
+        ContentInventoryAction content = new(_fileService.Root, useOrder: true, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
+        await content.RunAsync();
+
+        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, camelCasing: false, _fileService, _logger);
+        await index.RunAsync();
+
+        GenerateTocAction action = new(
+            _fileService.Root,
+            content.RootFolder!,
+            folderReferenceStrategy: TocFolderReferenceStrategy.None,
+            orderStrategy: TocOrderStrategy.FilesFirst,     // this is distinctive for this test
+            maxDepth: 0,
+            _fileService,
+            _logger);
+
+        int originalCount = _fileService.Files.Count();
+
+        string expected =
+@"# This is an automatically generated file
+- name: Docs
+- name: FilesOnly
+  items:
+  - name: C Document
+    href: FilesOnly/C.md
+  - name: B Document
+    href: FilesOnly/B.md
+  - name: A document
+    href: FilesOnly/A.md
+- name: FoldersAndFiles
+  items:
+  - name: BB
+    items:
+    - name: BB Document
+      href: FoldersAndFiles/BB/README.md
+  - name: B Document
+    href: FoldersAndFiles/B.md
+  - name: AA
+    items:
+    - name: AA Document
+      href: FoldersAndFiles/AA/README.md
+  - name: A document
+    href: FoldersAndFiles/A.md
+  - name: CC
+    items:
+    - name: CC Document
+      href: FoldersAndFiles/CC/README.md
+  - name: C Document
+    href: FoldersAndFiles/C.md
+- name: FoldersOnly
+  items:
+  - name: CC
+    items:
+    - name: CC Document
+      href: FoldersOnly/CC/README.md
+  - name: BB
+    items:
+    - name: BB Document
+      href: FoldersOnly/BB/README.md
+  - name: AA
+    items:
+    - name: AA Document
+      href: FoldersOnly/AA/README.md
+".NormalizeContent();
+
+        // act
+        ReturnCode ret = await action.RunAsync();
+
+        // assert
+        ret.Should().Be(ReturnCode.Normal);
+        _fileService.Files.Should().HaveCount(originalCount + 1);
+        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml"));
+        toc.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Run_Issue_86_OrderingFoldersFirst()
+    {
+        // arrange
+        Issue_86_Setup();
+
+        ContentInventoryAction content = new(_fileService.Root, useOrder: true, useIgnore: false, useOverride: false, camelCasing: false, _fileService, _logger);
+        await content.RunAsync();
+
+        EnsureIndexAction index = new(content.RootFolder!, Index.IndexGenerationStrategy.Never, camelCasing: false, _fileService, _logger);
+        await index.RunAsync();
+
+        GenerateTocAction action = new(
+            _fileService.Root,
+            content.RootFolder!,
+            folderReferenceStrategy: TocFolderReferenceStrategy.None,
+            orderStrategy: TocOrderStrategy.FoldersFirst,     // this is distinctive for this test
+            maxDepth: 0,
+            _fileService,
+            _logger);
+
+        int originalCount = _fileService.Files.Count();
+
+        string expected =
+@"# This is an automatically generated file
+- name: Docs
+- name: FilesOnly
+  items:
+  - name: C Document
+    href: FilesOnly/C.md
+  - name: B Document
+    href: FilesOnly/B.md
+  - name: A document
+    href: FilesOnly/A.md
+- name: FoldersAndFiles
+  items:
+  - name: BB
+    items:
+    - name: BB Document
+      href: FoldersAndFiles/BB/README.md
+  - name: B Document
+    href: FoldersAndFiles/B.md
+  - name: AA
+    items:
+    - name: AA Document
+      href: FoldersAndFiles/AA/README.md
+  - name: A document
+    href: FoldersAndFiles/A.md
+  - name: CC
+    items:
+    - name: CC Document
+      href: FoldersAndFiles/CC/README.md
+  - name: C Document
+    href: FoldersAndFiles/C.md
+- name: FoldersOnly
+  items:
+  - name: CC
+    items:
+    - name: CC Document
+      href: FoldersOnly/CC/README.md
+  - name: BB
+    items:
+    - name: BB Document
+      href: FoldersOnly/BB/README.md
+  - name: AA
+    items:
+    - name: AA Document
+      href: FoldersOnly/AA/README.md
+".NormalizeContent();
+
+        // act
+        ReturnCode ret = await action.RunAsync();
+
+        // assert
+        ret.Should().Be(ReturnCode.Normal);
+        _fileService.Files.Should().HaveCount(originalCount + 1);
+        string toc = _fileService.ReadAllText(_fileService.GetFullPath("toc.yml"));
+        toc.Should().Be(expected);
+    }
+
+    private void Issue_86_Setup()
+    {
+        _fileService.Files.Clear();
+
+        var folder = _fileService.AddFolder("FilesOnly");
+        _fileService.AddFile(folder, ".order",
+@"C
+B
+A");
+        _fileService.AddFile(folder, "A", string.Empty
+            .AddHeading("A Document", 1)
+            .AddParagraphs(1));
+        _fileService.AddFile(folder, "B", string.Empty
+            .AddHeading("B Document", 1)
+            .AddParagraphs(1));
+        _fileService.AddFile(folder, "C", string.Empty
+            .AddHeading("C Document", 1)
+            .AddParagraphs(1));
+
+        folder = _fileService.AddFolder("FoldersOnly");
+        _fileService.AddFile(folder, ".order",
+@"CC
+BB
+AA");
+        folder = _fileService.AddFolder("FoldersOnly/AA");
+        _fileService.AddFile(folder, "README.md", string.Empty
+            .AddHeading("AA Document", 1)
+            .AddParagraphs(1));
+        folder = _fileService.AddFolder("FoldersOnly/BB");
+        _fileService.AddFile(folder, "README.md", string.Empty
+            .AddHeading("BB Document", 1)
+            .AddParagraphs(1));
+        folder = _fileService.AddFolder("FoldersOnly/CC");
+        _fileService.AddFile(folder, "README.md", string.Empty
+            .AddHeading("CC Document", 1)
+            .AddParagraphs(1));
+
+        folder = _fileService.AddFolder("FoldersAndFiles");
+        _fileService.AddFile(folder, ".order",
+@"BB
+B
+AA
+A
+C
+CC");
+        _fileService.AddFile(folder, "A", string.Empty
+            .AddHeading("A Document", 1)
+            .AddParagraphs(1));
+        _fileService.AddFile(folder, "B", string.Empty
+            .AddHeading("B Document", 1)
+            .AddParagraphs(1));
+        _fileService.AddFile(folder, "C", string.Empty
+            .AddHeading("C Document", 1)
+            .AddParagraphs(1));
+        folder = _fileService.AddFolder("FoldersOnly/AA");
+        _fileService.AddFile(folder, "README.md", string.Empty
+            .AddHeading("AA Document", 1)
+            .AddParagraphs(1));
+        folder = _fileService.AddFolder("FoldersOnly/BB");
+        _fileService.AddFile(folder, "README.md", string.Empty
+            .AddHeading("BB Document", 1)
+            .AddParagraphs(1));
+        folder = _fileService.AddFolder("FoldersOnly/CC");
+        _fileService.AddFile(folder, "README.md", string.Empty
+            .AddHeading("CC Document", 1)
+            .AddParagraphs(1));
+    }
 }

--- a/src/DocFxTocGenerator/DocFxTocGenerator.Test/GenerateTocActionTests.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator.Test/GenerateTocActionTests.cs
@@ -417,8 +417,12 @@ public class GenerateTocActionTests
     href: FilesOnly/C.md
   - name: B Document
     href: FilesOnly/B.md
-  - name: A document
+  - name: A Document
     href: FilesOnly/A.md
+  - name: A1 Document
+    href: FilesOnly/A1.md
+  - name: A2 Document
+    href: FilesOnly/A2.md
 - name: FoldersAndFiles
   items:
   - name: BB
@@ -431,14 +435,18 @@ public class GenerateTocActionTests
     items:
     - name: AA Document
       href: FoldersAndFiles/AA/README.md
-  - name: A document
+  - name: A Document
     href: FoldersAndFiles/A.md
+  - name: C Document
+    href: FoldersAndFiles/C.md
   - name: CC
     items:
     - name: CC Document
       href: FoldersAndFiles/CC/README.md
-  - name: C Document
-    href: FoldersAndFiles/C.md
+  - name: A1 Document
+    href: FoldersAndFiles/A1.md
+  - name: A2 Document
+    href: FoldersAndFiles/A2.md
 - name: FoldersOnly
   items:
   - name: CC
@@ -497,28 +505,36 @@ public class GenerateTocActionTests
     href: FilesOnly/C.md
   - name: B Document
     href: FilesOnly/B.md
-  - name: A document
+  - name: A Document
     href: FilesOnly/A.md
+  - name: A1 Document
+    href: FilesOnly/A1.md
+  - name: A2 Document
+    href: FilesOnly/A2.md
 - name: FoldersAndFiles
   items:
+  - name: B Document
+    href: FoldersAndFiles/B.md
+  - name: A Document
+    href: FoldersAndFiles/A.md
+  - name: C Document
+    href: FoldersAndFiles/C.md
+  - name: A1 Document
+    href: FoldersAndFiles/A1.md
+  - name: A2 Document
+    href: FoldersAndFiles/A2.md
   - name: BB
     items:
     - name: BB Document
       href: FoldersAndFiles/BB/README.md
-  - name: B Document
-    href: FoldersAndFiles/B.md
   - name: AA
     items:
     - name: AA Document
       href: FoldersAndFiles/AA/README.md
-  - name: A document
-    href: FoldersAndFiles/A.md
   - name: CC
     items:
     - name: CC Document
       href: FoldersAndFiles/CC/README.md
-  - name: C Document
-    href: FoldersAndFiles/C.md
 - name: FoldersOnly
   items:
   - name: CC
@@ -577,28 +593,36 @@ public class GenerateTocActionTests
     href: FilesOnly/C.md
   - name: B Document
     href: FilesOnly/B.md
-  - name: A document
+  - name: A Document
     href: FilesOnly/A.md
+  - name: A1 Document
+    href: FilesOnly/A1.md
+  - name: A2 Document
+    href: FilesOnly/A2.md
 - name: FoldersAndFiles
   items:
   - name: BB
     items:
     - name: BB Document
       href: FoldersAndFiles/BB/README.md
-  - name: B Document
-    href: FoldersAndFiles/B.md
   - name: AA
     items:
     - name: AA Document
       href: FoldersAndFiles/AA/README.md
-  - name: A document
-    href: FoldersAndFiles/A.md
   - name: CC
     items:
     - name: CC Document
       href: FoldersAndFiles/CC/README.md
+  - name: B Document
+    href: FoldersAndFiles/B.md
+  - name: A Document
+    href: FoldersAndFiles/A.md
   - name: C Document
     href: FoldersAndFiles/C.md
+  - name: A1 Document
+    href: FoldersAndFiles/A1.md
+  - name: A2 Document
+    href: FoldersAndFiles/A2.md
 - name: FoldersOnly
   items:
   - name: CC
@@ -634,14 +658,20 @@ public class GenerateTocActionTests
 @"C
 B
 A");
-        _fileService.AddFile(folder, "A", string.Empty
+        _fileService.AddFile(folder, "A.md", string.Empty
             .AddHeading("A Document", 1)
             .AddParagraphs(1));
-        _fileService.AddFile(folder, "B", string.Empty
+        _fileService.AddFile(folder, "B.md", string.Empty
             .AddHeading("B Document", 1)
             .AddParagraphs(1));
-        _fileService.AddFile(folder, "C", string.Empty
+        _fileService.AddFile(folder, "C.md", string.Empty
             .AddHeading("C Document", 1)
+            .AddParagraphs(1));
+        _fileService.AddFile(folder, "A1.md", string.Empty
+            .AddHeading("A1 Document", 1)
+            .AddParagraphs(1));
+        _fileService.AddFile(folder, "A2.md", string.Empty
+            .AddHeading("A2 Document", 1)
             .AddParagraphs(1));
 
         folder = _fileService.AddFolder("FoldersOnly");
@@ -670,24 +700,30 @@ AA
 A
 C
 CC");
-        _fileService.AddFile(folder, "A", string.Empty
+        _fileService.AddFile(folder, "A.md", string.Empty
             .AddHeading("A Document", 1)
             .AddParagraphs(1));
-        _fileService.AddFile(folder, "B", string.Empty
+        _fileService.AddFile(folder, "B.md", string.Empty
             .AddHeading("B Document", 1)
             .AddParagraphs(1));
-        _fileService.AddFile(folder, "C", string.Empty
+        _fileService.AddFile(folder, "C.md", string.Empty
             .AddHeading("C Document", 1)
             .AddParagraphs(1));
-        folder = _fileService.AddFolder("FoldersOnly/AA");
+        _fileService.AddFile(folder, "A1.md", string.Empty
+            .AddHeading("A1 Document", 1)
+            .AddParagraphs(1));
+        _fileService.AddFile(folder, "A2.md", string.Empty
+            .AddHeading("A2 Document", 1)
+            .AddParagraphs(1));
+        folder = _fileService.AddFolder("FoldersAndFiles/AA");
         _fileService.AddFile(folder, "README.md", string.Empty
             .AddHeading("AA Document", 1)
             .AddParagraphs(1));
-        folder = _fileService.AddFolder("FoldersOnly/BB");
+        folder = _fileService.AddFolder("FoldersAndFiles/BB");
         _fileService.AddFile(folder, "README.md", string.Empty
             .AddHeading("BB Document", 1)
             .AddParagraphs(1));
-        folder = _fileService.AddFolder("FoldersOnly/CC");
+        folder = _fileService.AddFolder("FoldersAndFiles/CC");
         _fileService.AddFile(folder, "README.md", string.Empty
             .AddHeading("CC Document", 1)
             .AddParagraphs(1));

--- a/src/DocFxTocGenerator/DocFxTocGenerator/Actions/ContentInventoryAction.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/Actions/ContentInventoryAction.cs
@@ -2,6 +2,8 @@
 // Copyright (c) DocFx Companion Tools. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
+using System.Diagnostics;
+using System.Linq;
 using DocFxTocGenerator.ConfigFiles;
 using DocFxTocGenerator.FileService;
 using Microsoft.Extensions.Logging;
@@ -128,6 +130,14 @@ public class ContentInventoryAction
             {
                 folder.DisplayName = name;
                 folder.IsDisplayNameOverride = true;
+            }
+
+            // see if we have a sequence for the folder name
+            if (parent.OrderList.FindIndex(x => x.Equals(folder.Name, StringComparison.Ordinal)) != -1)
+            {
+                // set the order
+                folder.Sequence = parent.OrderList.FindIndex(x => x.Equals(folder.Name, StringComparison.Ordinal));
+                Debug.WriteLine($"Folder '{parent.Path}' Subfolder '{folder.Name}' Sequence '{folder.Sequence}'");
             }
         }
 

--- a/src/DocFxTocGenerator/DocFxTocGenerator/FileService/FileInfoService.cs
+++ b/src/DocFxTocGenerator/DocFxTocGenerator/FileService/FileInfoService.cs
@@ -2,6 +2,7 @@
 // Copyright (c) DocFx Companion Tools. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Markdig;
 using Markdig.Syntax;
@@ -65,6 +66,7 @@ public class FileInfoService
         {
             // set the order
             filedata.Sequence = folder.OrderList.FindIndex(x => x.Equals(fname, comparison));
+            Debug.WriteLine($"Folder '{folder.Path}' File '{filedata.Name}' Sequence '{filedata.Sequence}'");
         }
 
         var title = GetFileDisplayName(file, _camelCasing);


### PR DESCRIPTION
Ordering files and folders using .order files didn't work properly. Folders were not ordered following .order definition. That is fixed now. Added tests to simulate the problem and validate the fix.

This closes #86 