### PR TITLE
Fixed mailto reference detection

### DIFF
--- a/src/DocAssembler/DocAssembler/FileService/Hyperlink.cs
+++ b/src/DocAssembler/DocAssembler/FileService/Hyperlink.cs
@@ -22,8 +22,8 @@ public class Hyperlink
         { "http://", HyperlinkType.Webpage },
         { "ftps://", HyperlinkType.Ftp },
         { "ftp://", HyperlinkType.Ftp },
-        { "mailto://", HyperlinkType.Mail },
-        { "xref://", HyperlinkType.CrossReference },
+        { "mailto:", HyperlinkType.Mail },
+        { "xref:", HyperlinkType.CrossReference },
     };
 
     private static readonly char[] _uriFragmentOrQueryString = new char[] { '#', '?' };


### PR DESCRIPTION
mailto: reference links are now properly detected in DocAssembler. Added test to validate.

This closes #92 