### PR TITLE
Fixed issue #95. Validated with test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # User-specific files
 *.zip
 [Oo]utput/
+[Oo]ut/
 launchSettings.json
 
 *.rsuser

--- a/src/DocLinkChecker/DocLinkChecker.Test/MarkdownTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/MarkdownTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace DocLinkChecker.Test
 {
     using System.Linq;
-    using System.Reflection;
-    using System.Text.RegularExpressions;
     using DocLinkChecker.Helpers;
     using DocLinkChecker.Models;
     using DocLinkChecker.Test.Helpers;
@@ -89,6 +87,26 @@
                 .ToList();
 
             headings.Count.Should().Be(6);
+        }
+
+        /// <summary>
+        /// Test for issue #95 - fix underscore in heading. should be kept in link.
+        /// </summary>
+        [Fact]
+        public void FindAllHeadingsWithUnderscore()
+        {
+            string markdown = string.Empty
+                .AddHeading("A header with under_score", 1)
+                .AddParagraphs(1).AddLink("#a-header-with-under_score");
+
+            var result = MarkdownHelper.ParseMarkdownString(string.Empty, markdown, true);
+
+            var headings = result.Objects
+                .OfType<Heading>()
+                .ToList();
+
+            headings.Count.Should().Be(1);
+            headings[0].Id.Should().Be("a-header-with-under_score");
         }
 
         [Fact]

--- a/src/DocLinkChecker/DocLinkChecker/Helpers/MarkdownHelper.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Helpers/MarkdownHelper.cs
@@ -102,10 +102,10 @@ namespace DocLinkChecker.Helpers
 
                     // custom generation of the id
                     string id = title.ToLower();
-                    id = Regex.Replace(id, "[ _]", "-");
+                    id = Regex.Replace(id, "[ ]", "-");
 
                     // replace all non-characters. \p[L] takes all unicode variants in account as well like ö and á
-                    id = Regex.Replace(id, @"[^\p{L}0-9-]*", string.Empty);
+                    id = Regex.Replace(id, @"[^\p{L}0-9-_]*", string.Empty);
 
                     return new Heading(markdownFilePath, x.Line + 1, x.Column + 1, title, id);
                 })


### PR DESCRIPTION
Underscore is now kept in link to header with underscore in text.