### PR TITLE
DocLinkChecker: Fixed heading with trailing spaces

### DIFF
--- a/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/HyperlinkTests.cs
@@ -281,6 +281,7 @@
         [Theory]
         [InlineData("First header", "first-header", "#first-header")]
         [InlineData("`Second header`", "second-header", "#second-header")]
+        [InlineData("🔎 Icon header", "-icon-header", "#-icon-header")]
         public async void ValidateLocalLinkHeadingInSameDocumentShouldNotHaveErrors(string title, string id, string reference)
         {
             // Arrange

--- a/src/DocLinkChecker/DocLinkChecker.Test/MarkdownTests.cs
+++ b/src/DocLinkChecker/DocLinkChecker.Test/MarkdownTests.cs
@@ -62,6 +62,23 @@
         }
 
         [Fact]
+        public void Issue111_heading_with_spaces_at_end_should_be_addressable()
+        {
+            string markdown = string.Empty
+                .AddHeading("🔎 Rationale & Supporting Evidence  ", 2)
+                .AddParagraphs(1).AddLink("#-rationale--supporting-evidence");
+
+            var result = MarkdownHelper.ParseMarkdownString(string.Empty, markdown, true);
+
+            var headings = result.Objects
+                .OfType<Heading>()
+                .ToList();
+
+            headings.Count.Should().Be(1);
+            headings[0].Id.Should().Be("-rationale--supporting-evidence");
+        }
+
+        [Fact]
         public void FindAllLinks()
         {
             var result = MarkdownHelper.ParseMarkdownString(string.Empty, _correctDocument, true);

--- a/src/DocLinkChecker/DocLinkChecker/Helpers/MarkdownHelper.cs
+++ b/src/DocLinkChecker/DocLinkChecker/Helpers/MarkdownHelper.cs
@@ -101,7 +101,7 @@ namespace DocLinkChecker.Helpers
                     }
 
                     // custom generation of the id
-                    string id = title.ToLower();
+                    string id = title.ToLower().Trim();
                     id = Regex.Replace(id, "[ ]", "-");
 
                     // replace all non-characters. \p[L] takes all unicode variants in account as well like ö and á


### PR DESCRIPTION
When a heading has trailing spaces, like this:

```
## 🔎 Rationale & Supporting Evidence  

The heading above ends with trailing spaces
```

the generated id for the heading is "-rationale--supporting-evidence--", which is not how mardig works as it trims the trailing spaces. This fix added trimming spaces from the header to get the correct id.