### PR TITLE
Added line range translation support to DocLanguageTranslator CLI

### DIFF
--- a/src/DocLanguageTranslator/DocLanguageTranslator.Test/DocFxLanguageGeneratorTests.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator.Test/DocFxLanguageGeneratorTests.cs
@@ -245,4 +245,305 @@ public sealed class DocFxLanguageGeneratorTests
         Assert.True(mockFileService.Files.ContainsKey("docs/fr/file1.md"));
         Assert.Contains("# Bonjour", mockFileService.Files["docs/fr/file1.md"]);
     }
+
+    [Fact]
+    public void LineRange_WithoutSourceFile_ReturnsError()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            Key = "valid-key",
+            LineRange = "1-10",
+        };
+
+        DocFxLanguageGenerator generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(1, returnValue);
+        Assert.Contains("ERROR: --sourcefile is required when using --lines option.", mockMessageHelper.Errors);
+    }
+
+    [Fact]
+    public void LineRange_WithInvalidFormat_ReturnsError()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+        mockFileService.WriteAllText("docs/en/file1.md", "# Hello\nLine 2\nLine 3");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            Key = "valid-key",
+            SourceFile = "docs/en/file1.md",
+            LineRange = "invalid",
+        };
+
+        DocFxLanguageGenerator generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(1, returnValue);
+        Assert.Contains("ERROR: Invalid line range format. Use format like '1-10' or '5-20'.", mockMessageHelper.Errors);
+    }
+
+    [Fact]
+    public void LineRange_WithNonExistentSourceFile_ReturnsError()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            Key = "valid-key",
+            SourceFile = "docs/en/nonexistent.md",
+            LineRange = "1-10",
+        };
+
+        DocFxLanguageGenerator generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(1, returnValue);
+        Assert.Contains("ERROR: Source file 'docs/en/nonexistent.md' doesn't exist.", mockMessageHelper.Errors);
+    }
+
+    [Fact]
+    public void LineRange_TranslatesSpecificLinesInExistingFiles()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+        mockFileService.CreateDirectory("docs/fr");
+        mockFileService.WriteAllText("docs/en/file1.md", "# Title\nLine 2 English\nLine 3 English\nLine 4");
+        mockFileService.WriteAllText("docs/fr/file1.md", "# Titre\nLine 2 French OLD\nLine 3 French OLD\nLigne 4");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            Key = "valid-key",
+            SourceFile = "docs/en/file1.md",
+            LineRange = "2-3",
+            Verbose = true,
+        };
+
+        mockTranslationService
+            .Setup(t => t.TranslateAsync(It.IsAny<string>(), "en", "fr"))
+            .ReturnsAsync((string text, string _, string _) =>
+                text.Replace("English", "French NEW"));
+
+        DocFxLanguageGenerator generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(0, returnValue);
+        string resultContent = mockFileService.Files["docs/fr/file1.md"];
+        Assert.Contains("# Titre", resultContent);
+        Assert.Contains("French NEW", resultContent);
+        Assert.Contains("Ligne 4", resultContent);
+        Assert.DoesNotContain("French OLD", resultContent);
+    }
+
+    [Fact]
+    public void LineRange_WarnsWhenTargetFileDoesNotExist()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+        mockFileService.CreateDirectory("docs/fr");
+        mockFileService.WriteAllText("docs/en/file1.md", "# Title\nLine 2");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            Key = "valid-key",
+            SourceFile = "docs/en/file1.md",
+            LineRange = "1-2",
+            Verbose = true,
+        };
+
+        DocFxLanguageGenerator generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(0, returnValue);
+        Assert.Contains(mockMessageHelper.Warnings, w => w.Contains("doesn't exist. Skipping."));
+    }
+
+    [Fact]
+    public void LineRange_WithCheckOnly_ReportsErrorWhenTargetFileMissing()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+        mockFileService.CreateDirectory("docs/fr");
+        mockFileService.WriteAllText("docs/en/file1.md", "# Title\nLine 2");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            SourceFile = "docs/en/file1.md",
+            LineRange = "1-2",
+            CheckOnly = true,
+            Verbose = true,
+        };
+
+        DocFxLanguageGenerator generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(1, returnValue);
+        Assert.Contains(mockMessageHelper.Errors, e => e.Contains("Target file") && e.Contains("doesn't exist."));
+        mockTranslationService.Verify(t => t.TranslateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void LineRange_WithCheckOnly_SucceedsWhenAllTargetFilesExist()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+        mockFileService.CreateDirectory("docs/fr");
+        mockFileService.WriteAllText("docs/en/file1.md", "# Title\nLine 2 to translate\nLine 3 to translate");
+        mockFileService.WriteAllText("docs/fr/file1.md", "# Titre\nLigne 2\nLigne 3");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            SourceFile = "docs/en/file1.md",
+            LineRange = "2-3",
+            CheckOnly = true,
+            Verbose = true,
+        };
+
+        DocFxLanguageGenerator generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(0, returnValue);
+        Assert.Empty(mockMessageHelper.Errors);
+        mockTranslationService.Verify(t => t.TranslateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
+        // Verify output shows which files would be translated
+        Assert.Contains(mockMessageHelper.VerboseMessages, m => m.Contains("Would translate lines 2-3 from 'docs/en/file1.md' to 'docs/fr/file1.md'"));
+
+        // Verify output shows the lines that would be translated
+        Assert.Contains(mockMessageHelper.VerboseMessages, m => m.Contains("Line 2: Line 2 to translate"));
+        Assert.Contains(mockMessageHelper.VerboseMessages, m => m.Contains("Line 3: Line 3 to translate"));
+    }
+
+    [Fact]
+    public void LineRange_WithCheckOnly_DoesNotRequireKey()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+        mockFileService.CreateDirectory("docs/fr");
+        mockFileService.WriteAllText("docs/en/file1.md", "# Title\nLine 2");
+        mockFileService.WriteAllText("docs/fr/file1.md", "# Titre\nLigne 2");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            SourceFile = "docs/en/file1.md",
+            LineRange = "1-2",
+            CheckOnly = true,
+            Key = null, // No key provided
+        };
+
+        DocFxLanguageGenerator generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(0, returnValue);
+    }
+
+    [Theory]
+    [InlineData("1-10", 1, 10, true)]
+    [InlineData("5-20", 5, 20, true)]
+    [InlineData("100-200", 100, 200, true)]
+    [InlineData("1-1", 1, 1, true)]
+    [InlineData("", 0, 0, false)]
+    [InlineData("invalid", 0, 0, false)]
+    [InlineData("1", 0, 0, false)]
+    [InlineData("1-", 0, 0, false)]
+    [InlineData("-10", 0, 0, false)]
+    [InlineData("10-5", 0, 0, false)]
+    [InlineData("0-10", 0, 0, false)]
+    [InlineData("-1-10", 0, 0, false)]
+    public void TryParseLineRange_ParsesCorrectly(string input, int expectedStart, int expectedEnd, bool expectedResult)
+    {
+        // Arrange
+        var generator = new DocFxLanguageGenerator(
+            new CommandlineOptions(),
+            mockFileService,
+            Mock.Of<ITranslationService>(),
+            mockMessageHelper);
+
+        // Act
+        bool result = generator.TryParseLineRange(input, out int startLine, out int endLine);
+
+        // Assert
+        Assert.Equal(expectedResult, result);
+        if (expectedResult)
+        {
+            Assert.Equal(expectedStart, startLine);
+            Assert.Equal(expectedEnd, endLine);
+        }
+    }
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator.Test/DocFxLanguageGeneratorTests.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator.Test/DocFxLanguageGeneratorTests.cs
@@ -271,7 +271,7 @@ public sealed class DocFxLanguageGeneratorTests
 
         // Assert
         Assert.Equal(1, returnValue);
-        Assert.Contains("ERROR: --sourcefile is required when using --lines option.", mockMessageHelper.Errors);
+        Assert.NotEmpty(mockMessageHelper.Errors);
     }
 
     [Fact]
@@ -301,7 +301,7 @@ public sealed class DocFxLanguageGeneratorTests
 
         // Assert
         Assert.Equal(1, returnValue);
-        Assert.Contains("ERROR: Invalid line range format. Use format like '1-10' or '5-20'.", mockMessageHelper.Errors);
+        Assert.NotEmpty(mockMessageHelper.Errors);
     }
 
     [Fact]
@@ -330,7 +330,7 @@ public sealed class DocFxLanguageGeneratorTests
 
         // Assert
         Assert.Equal(1, returnValue);
-        Assert.Contains("ERROR: Source file 'docs/en/nonexistent.md' doesn't exist.", mockMessageHelper.Errors);
+        Assert.NotEmpty(mockMessageHelper.Errors);
     }
 
     [Fact]
@@ -404,7 +404,7 @@ public sealed class DocFxLanguageGeneratorTests
 
         // Assert
         Assert.Equal(0, returnValue);
-        Assert.Contains(mockMessageHelper.Warnings, w => w.Contains("doesn't exist. Skipping."));
+        Assert.NotEmpty(mockMessageHelper.Warnings);
     }
 
     [Fact]
@@ -436,7 +436,7 @@ public sealed class DocFxLanguageGeneratorTests
 
         // Assert
         Assert.Equal(1, returnValue);
-        Assert.Contains(mockMessageHelper.Errors, e => e.Contains("Target file") && e.Contains("doesn't exist."));
+        Assert.NotEmpty(mockMessageHelper.Errors);
         mockTranslationService.Verify(t => t.TranslateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 

--- a/src/DocLanguageTranslator/DocLanguageTranslator.Test/Helpers/MockFileService.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator.Test/Helpers/MockFileService.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to DocFX Companion Tools and contributors under one or more agreements.
 // DocFX Companion Tools and contributors licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using DocLanguageTranslator.FileService;
 using System.IO;
@@ -35,5 +36,46 @@ public class MockFileService : IFileService
     {
         if (!Directories.Contains(path))
             Directories.Add(path);
+    }
+
+    public string[] ReadAllLines(string filePath)
+    {
+        if (Files.TryGetValue(filePath, out var content))
+        {
+            return content.Split('\n');
+        }
+
+        return [];
+    }
+
+    public string[] ReadLines(string filePath, int startLine, int endLine)
+    {
+        var allLines = ReadAllLines(filePath);
+        int start = Math.Max(0, startLine - 1);
+        int end = Math.Min(allLines.Length, endLine);
+        int count = end - start;
+
+        if (count <= 0)
+        {
+            return [];
+        }
+
+        return allLines.Skip(start).Take(count).ToArray();
+    }
+
+    public void ReplaceLines(string filePath, int startLine, int endLine, string[] newLines)
+    {
+        var allLines = ReadAllLines(filePath).ToList();
+        int start = Math.Max(0, startLine - 1);
+        int end = Math.Min(allLines.Count, endLine);
+        int count = end - start;
+
+        if (count > 0)
+        {
+            allLines.RemoveRange(start, count);
+        }
+
+        allLines.InsertRange(start, newLines);
+        WriteAllText(filePath, string.Join("\n", allLines));
     }
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator.Test/Helpers/MockFileService.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator.Test/Helpers/MockFileService.cs
@@ -42,7 +42,7 @@ public class MockFileService : IFileService
     {
         if (Files.TryGetValue(filePath, out var content))
         {
-            return content.Split('\n');
+            return content.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
         }
 
         return [];

--- a/src/DocLanguageTranslator/DocLanguageTranslator/DocFxLanguageGenerator.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/DocFxLanguageGenerator.cs
@@ -408,8 +408,18 @@ namespace DocFXLanguageGenerator
                     continue;
                 }
 
-                // Determine target file path
-                string targetFile = normalizedSourceFile.Replace(sourceDir, normalizedLangDir);
+                // Determine target file path by replacing only the language directory prefix
+                string targetFile;
+                if (normalizedSourceFile.StartsWith(sourceDir, StringComparison.OrdinalIgnoreCase))
+                {
+                    targetFile = normalizedLangDir + normalizedSourceFile.Substring(sourceDir.Length);
+                }
+                else
+                {
+                    // Fallback: if the source file path does not start with the expected sourceDir,
+                    // leave it unchanged rather than performing a global replacement.
+                    targetFile = normalizedSourceFile;
+                }
 
                 if (!fileService.FileExists(targetFile))
                 {

--- a/src/DocLanguageTranslator/DocLanguageTranslator/Domain/CommandlineOptions.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/Domain/CommandlineOptions.cs
@@ -37,5 +37,15 @@ namespace DocFXLanguageGenerator.Domain
         /// Gets or sets a value indicating whether to only check files are missing.
         /// </summary>
         public bool CheckOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source file path for line range translation.
+        /// </summary>
+        public string SourceFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the line range to translate (e.g., "1-10" or "5-20").
+        /// </summary>
+        public string LineRange { get; set; }
     }
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/FileService/FileService.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/FileService/FileService.cs
@@ -33,4 +33,41 @@ internal class FileService : IFileService
     /// <inheritdoc/>
     public void CreateDirectory(string path)
         => Directory.CreateDirectory(path);
+
+    /// <inheritdoc/>
+    public string[] ReadAllLines(string filePath)
+        => File.ReadAllLines(filePath);
+
+    /// <inheritdoc/>
+    public string[] ReadLines(string filePath, int startLine, int endLine)
+    {
+        var allLines = File.ReadAllLines(filePath);
+        int start = Math.Max(0, startLine - 1);
+        int end = Math.Min(allLines.Length, endLine);
+        int count = end - start;
+
+        if (count <= 0)
+        {
+            return [];
+        }
+
+        return allLines.Skip(start).Take(count).ToArray();
+    }
+
+    /// <inheritdoc/>
+    public void ReplaceLines(string filePath, int startLine, int endLine, string[] newLines)
+    {
+        var allLines = File.ReadAllLines(filePath).ToList();
+        int start = Math.Max(0, startLine - 1);
+        int end = Math.Min(allLines.Count, endLine);
+        int count = end - start;
+
+        if (count > 0)
+        {
+            allLines.RemoveRange(start, count);
+        }
+
+        allLines.InsertRange(start, newLines);
+        File.WriteAllLines(filePath, allLines);
+    }
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/FileService/IFileService.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/FileService/IFileService.cs
@@ -59,4 +59,29 @@ internal interface IFileService
     /// </summary>
     /// <param name="path">The path of the directory to create.</param>
     void CreateDirectory(string path);
+
+    /// <summary>
+    /// Reads all lines from the specified file.
+    /// </summary>
+    /// <param name="filePath">The path to the file to read.</param>
+    /// <returns>An array of strings containing all lines in the file.</returns>
+    string[] ReadAllLines(string filePath);
+
+    /// <summary>
+    /// Reads a specific range of lines from the specified file.
+    /// </summary>
+    /// <param name="filePath">The path to the file to read.</param>
+    /// <param name="startLine">The 1-based starting line number.</param>
+    /// <param name="endLine">The 1-based ending line number (inclusive).</param>
+    /// <returns>An array of strings containing the specified lines.</returns>
+    string[] ReadLines(string filePath, int startLine, int endLine);
+
+    /// <summary>
+    /// Replaces a specific range of lines in a file with new content.
+    /// </summary>
+    /// <param name="filePath">The path to the file to modify.</param>
+    /// <param name="startLine">The 1-based starting line number to replace.</param>
+    /// <param name="endLine">The 1-based ending line number to replace (inclusive).</param>
+    /// <param name="newLines">The new lines to insert in place of the original range.</param>
+    void ReplaceLines(string filePath, int startLine, int endLine, string[] newLines);
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/Program.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/Program.cs
@@ -49,6 +49,14 @@ namespace DocFXLanguageGenerator
                 description: "Check missing files in structure only.",
                 getDefaultValue: () => false);
 
+            var sourceFileOption = new Option<string>(
+                aliases: ["--sourcefile", "-f"],
+                description: "The source file path for line range translation.");
+
+            var lineRangeOption = new Option<string>(
+                aliases: ["--lines", "-r"],
+                description: "The range of lines to translate (e.g., '1-10' or '5-20'). Requires --sourcefile.");
+
             // Add options to root command
             rootCommand.AddOption(docFolderOption);
             rootCommand.AddOption(verboseOption);
@@ -56,6 +64,8 @@ namespace DocFXLanguageGenerator
             rootCommand.AddOption(locationOption);
             rootCommand.AddOption(sourceLanguageOption);
             rootCommand.AddOption(checkOnlyOption);
+            rootCommand.AddOption(sourceFileOption);
+            rootCommand.AddOption(lineRangeOption);
 
             // Set command handler
             rootCommand.SetHandler(context =>
@@ -68,6 +78,8 @@ namespace DocFXLanguageGenerator
                     Location = context.ParseResult.GetValueForOption(locationOption),
                     SourceLanguage = context.ParseResult.GetValueForOption(sourceLanguageOption),
                     CheckOnly = context.ParseResult.GetValueForOption(checkOnlyOption),
+                    SourceFile = context.ParseResult.GetValueForOption(sourceFileOption),
+                    LineRange = context.ParseResult.GetValueForOption(lineRangeOption),
                 };
 
                 context.ExitCode = RunLogic(options);

--- a/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/FullFileTranslationMode.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/FullFileTranslationMode.cs
@@ -28,7 +28,12 @@ internal class FullFileTranslationMode : ITranslationMode
     /// <inheritdoc/>
     public void WriteContent(IFileService fileService, string outputFile, string translatedContent)
     {
-        ensureDirectoryExists(Path.GetDirectoryName(outputFile));
+        var directory = Path.GetDirectoryName(outputFile);
+        if (directory is not null)
+        {
+            ensureDirectoryExists(directory);
+        }
+
         fileService.WriteAllText(outputFile, translatedContent);
     }
 

--- a/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/FullFileTranslationMode.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/FullFileTranslationMode.cs
@@ -1,0 +1,45 @@
+// Licensed to DocFX Companion Tools and contributors under one or more agreements.
+// DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+
+using DocLanguageTranslator.FileService;
+
+namespace DocLanguageTranslator.TranslationMode;
+
+/// <summary>
+/// Translation mode for translating an entire file and writing to a new output file.
+/// </summary>
+internal class FullFileTranslationMode : ITranslationMode
+{
+    private readonly Action<string> ensureDirectoryExists;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FullFileTranslationMode"/> class.
+    /// </summary>
+    /// <param name="ensureDirectoryExists">Action to ensure the output directory exists.</param>
+    public FullFileTranslationMode(Action<string> ensureDirectoryExists)
+    {
+        this.ensureDirectoryExists = ensureDirectoryExists;
+    }
+
+    /// <inheritdoc/>
+    public string ReadContent(IFileService fileService, string inputFile)
+        => fileService.ReadAllText(inputFile);
+
+    /// <inheritdoc/>
+    public void WriteContent(IFileService fileService, string outputFile, string translatedContent)
+    {
+        ensureDirectoryExists(Path.GetDirectoryName(outputFile));
+        fileService.WriteAllText(outputFile, translatedContent);
+    }
+
+    /// <inheritdoc/>
+    public string FormatStartMessage(string inputFile, string outputFile, string sourceLang, string targetLang)
+        => $"Translating {inputFile} [{sourceLang} to {targetLang}]";
+
+    /// <inheritdoc/>
+    public string FormatCompletionMessage(string outputFile)
+        => $"Saving {outputFile}";
+
+    /// <inheritdoc/>
+    public string GetNoContentErrorMessage() => null;
+}

--- a/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/ITranslationMode.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/ITranslationMode.cs
@@ -1,0 +1,51 @@
+// Licensed to DocFX Companion Tools and contributors under one or more agreements.
+// DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+
+using DocLanguageTranslator.FileService;
+
+namespace DocLanguageTranslator.TranslationMode;
+
+/// <summary>
+/// Defines the strategy for reading source content and writing translated content.
+/// </summary>
+internal interface ITranslationMode
+{
+    /// <summary>
+    /// Reads the content to be translated from the source file.
+    /// </summary>
+    /// <param name="fileService">The file service.</param>
+    /// <param name="inputFile">The input file path.</param>
+    /// <returns>The content to translate, or null if reading failed.</returns>
+    string ReadContent(IFileService fileService, string inputFile);
+
+    /// <summary>
+    /// Writes the translated content to the output file.
+    /// </summary>
+    /// <param name="fileService">The file service.</param>
+    /// <param name="outputFile">The output file path.</param>
+    /// <param name="translatedContent">The translated content to write.</param>
+    void WriteContent(IFileService fileService, string outputFile, string translatedContent);
+
+    /// <summary>
+    /// Gets a descriptive message for verbose logging when starting translation.
+    /// </summary>
+    /// <param name="inputFile">The input file path.</param>
+    /// <param name="outputFile">The output file path.</param>
+    /// <param name="sourceLang">The source language.</param>
+    /// <param name="targetLang">The target language.</param>
+    /// <returns>A formatted message describing the translation operation.</returns>
+    string FormatStartMessage(string inputFile, string outputFile, string sourceLang, string targetLang);
+
+    /// <summary>
+    /// Gets a descriptive message for verbose logging when translation is complete.
+    /// </summary>
+    /// <param name="outputFile">The output file path.</param>
+    /// <returns>A formatted completion message.</returns>
+    string FormatCompletionMessage(string outputFile);
+
+    /// <summary>
+    /// Gets the error message to display when no content is found to translate.
+    /// </summary>
+    /// <returns>An error message, or null if no specific error message is needed.</returns>
+    string GetNoContentErrorMessage();
+}

--- a/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/LineRangeTranslationMode.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/LineRangeTranslationMode.cs
@@ -1,0 +1,52 @@
+// Licensed to DocFX Companion Tools and contributors under one or more agreements.
+// DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+
+using DocLanguageTranslator.FileService;
+
+namespace DocLanguageTranslator.TranslationMode;
+
+/// <summary>
+/// Translation mode for translating a specific range of lines and replacing them in an existing file.
+/// </summary>
+internal class LineRangeTranslationMode : ITranslationMode
+{
+    private readonly int startLine;
+    private readonly int endLine;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LineRangeTranslationMode"/> class.
+    /// </summary>
+    /// <param name="startLine">The 1-based starting line number.</param>
+    /// <param name="endLine">The 1-based ending line number (inclusive).</param>
+    public LineRangeTranslationMode(int startLine, int endLine)
+    {
+        this.startLine = startLine;
+        this.endLine = endLine;
+    }
+
+    /// <inheritdoc/>
+    public string ReadContent(IFileService fileService, string inputFile)
+    {
+        string[] sourceLines = fileService.ReadLines(inputFile, startLine, endLine);
+        return sourceLines.Length == 0 ? null : string.Join(Environment.NewLine, sourceLines);
+    }
+
+    /// <inheritdoc/>
+    public void WriteContent(IFileService fileService, string outputFile, string translatedContent)
+    {
+        string[] translatedLines = translatedContent.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+        fileService.ReplaceLines(outputFile, startLine, endLine, translatedLines);
+    }
+
+    /// <inheritdoc/>
+    public string FormatStartMessage(string inputFile, string outputFile, string sourceLang, string targetLang)
+        => $"Translating lines {startLine}-{endLine} from {inputFile} to {outputFile} [{sourceLang} to {targetLang}]";
+
+    /// <inheritdoc/>
+    public string FormatCompletionMessage(string outputFile)
+        => $"Updated lines {startLine}-{endLine} in {outputFile}";
+
+    /// <inheritdoc/>
+    public string GetNoContentErrorMessage()
+        => $"ERROR: No lines found in range {startLine}-{endLine}.";
+}

--- a/src/DocLanguageTranslator/README.md
+++ b/src/DocLanguageTranslator/README.md
@@ -46,6 +46,8 @@ Options:
   -l, --location <location>               The translator Azure Cognitive Services location. [default: westeurope]
   -s, --source <language>                 The source language of files to use for missing translations.
   -c, --check                             Check missing files in structure only. [default: False]
+  -f, --sourcefile <sourcefile>           The source file path for line range translation.
+  -r, --lines <lines>                     The range of lines to translate (e.g., '1-10'). Requires --sourcefile.
   --version                               Show version information
   -?, -h, --help                          Show help and usage information
 ```
@@ -145,6 +147,49 @@ In the previous example, "en" is automatically selected as the source language t
 To explicitly set the source language, pass the language code to the `-s or --source` command line option.
 
 In this case, only missing files which exist in the source language directory will be used for translations.
+
+### Translating specific line ranges
+
+If you only need to translate a specific range of lines from a source document (instead of the entire file), you can use the `-r or --lines` option together with the `-f or --sourcefile` option.
+This is useful when you've updated a specific section of a document and want to apply that change to all translated versions without re-translating the entire file.
+
+**Example:**
+
+```bash
+DocLanguageTranslator -d c:\path\userdocs -k your-key -f c:\path\userdocs\en\file1.md -r 10-25
+```
+
+This command will:
+
+1. Read lines 10-25 from `c:\path\userdocs\en\file1.md`
+2. Translate those lines to all other language directories (e.g., `de`, `fr`, `zh-Hans`)
+3. Replace lines 10-25 in the corresponding target files with the translated content
+
+**Requirements:**
+
+* The `--sourcefile` option is required when using `--lines`
+* The source file must exist within the documentation folder
+* Target files must already exist in other language directories
+* The line range format must be `start-end` (e.g., `1-10`, `5-20`)
+* Line numbers are 1-based and inclusive
+
+**Notes:**
+
+* If a target file doesn't exist, a warning will be displayed and that language will be skipped
+* Use the `--check` option with `--lines` to verify that target files exist without translating
+* When using `--check` with `--lines`, verbose output (`-v`) will display which files would be translated and show the specific lines that would be translated
+
+**Check-only mode example:**
+
+```bash
+DocLanguageTranslator -d c:\path\userdocs -f c:\path\userdocs\en\file1.md -r 10-25 --check -v
+```
+
+This will verify that target files exist in all language directories without performing any translation. With verbose mode enabled, it will also display:
+
+* Which target files would receive the translated content
+* The source and target languages for each translation
+* The actual content of the lines that would be translated
 
 ### Limitations
 

--- a/src/DocLanguageTranslator/README.md
+++ b/src/DocLanguageTranslator/README.md
@@ -191,6 +191,8 @@ This will verify that target files exist in all language directories without per
 * The source and target languages for each translation
 * The actual content of the lines that would be translated
 
+> **Design note:** The explicit line range approach was chosen over automatic change detection (e.g., diff-based or marker-based) because it is simpler, fully predictable, and does not depend on version control state or special syntax in documents. The trade-off is that users must identify the line numbers themselves, but this keeps the tool deterministic and free of hidden heuristics.
+
 ### Limitations
 
 * The translation process is not perfect! It is more than strongly encouraged to have someone speaking natively the language to help in doing the translation in a better way.


### PR DESCRIPTION
Enabled translation of specific line ranges in markdown files via new --sourcefile and --lines options. Refactored translation logic with ITranslationMode interface and added FullFileTranslationMode and LineRangeTranslationMode. Extended IFileService for line-based operations.
Updated error handling, validation, and added tests. Documented new features and usage in README.

Fixes #101