### PR TITLE
Add --insert option to insert translated lines in range

### DIFF
--- a/src/DocLanguageTranslator/DocLanguageTranslator.Test/Helpers/MockFileService.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator.Test/Helpers/MockFileService.cs
@@ -81,4 +81,12 @@ public class MockFileService : IFileService
         allLines.InsertRange(start, newLines);
         WriteAllText(filePath, string.Join("\n", allLines));
     }
+
+    public void InsertLines(string filePath, int insertBeforeLine, string[] newLines)
+    {
+        var allLines = ReadAllLines(filePath).ToList();
+        int index = Math.Clamp(insertBeforeLine - 1, 0, allLines.Count);
+        allLines.InsertRange(index, newLines);
+        WriteAllText(filePath, string.Join("\n", allLines));
+    }
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/DocFxLanguageGenerator.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/DocFxLanguageGenerator.cs
@@ -63,6 +63,7 @@ namespace DocFXLanguageGenerator
             messageHelper.Verbose($"Source language     : {options.SourceLanguage}");
             messageHelper.Verbose($"Source file         : {options.SourceFile}");
             messageHelper.Verbose($"Line range          : {options.LineRange}");
+            messageHelper.Verbose($"Insert lines        : {options.InsertLines}");
 
             if (string.IsNullOrEmpty(subscriptionKey) && !options.CheckOnly)
             {
@@ -421,7 +422,11 @@ namespace DocFXLanguageGenerator
             }
 
             string sourceLang = GetLanguageCodeFromPath(sourceDir);
-            var lineRangeMode = new LineRangeTranslationMode(startLine, endLine);
+
+            ITranslationMode translationMode = options.InsertLines
+                ? new LineInsertTranslationMode(startLine, endLine)
+                : new LineRangeTranslationMode(startLine, endLine);
+
             int numberOfFiles = 0;
 
             foreach (var langDir in allLanguagesDirectories)
@@ -467,7 +472,8 @@ namespace DocFXLanguageGenerator
                 if (options.CheckOnly)
                 {
                     // Show what would be translated
-                    messageHelper.Verbose($"Would translate lines {startLine}-{endLine} from '{options.SourceFile}' to '{targetFile}' [{sourceLang} to {targetLang}]");
+                    string action = options.InsertLines ? "insert" : "replace";
+                    messageHelper.Verbose($"Would translate and {action} lines {startLine}-{endLine} from '{options.SourceFile}' to '{targetFile}' [{sourceLang} to {targetLang}]");
                     string[] sourceLines = fileService.ReadLines(options.SourceFile, startLine, endLine);
                     for (int i = 0; i < sourceLines.Length; i++)
                     {
@@ -476,7 +482,7 @@ namespace DocFXLanguageGenerator
 
                     numberOfFiles++;
                 }
-                else if (TranslateFile(options.SourceFile, sourceLang, targetFile, targetLang, lineRangeMode))
+                else if (TranslateFile(options.SourceFile, sourceLang, targetFile, targetLang, translationMode))
                 {
                     numberOfFiles++;
                 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/Domain/CommandlineOptions.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/Domain/CommandlineOptions.cs
@@ -47,5 +47,11 @@ namespace DocFXLanguageGenerator.Domain
         /// Gets or sets the line range to translate (e.g., "1-10" or "5-20").
         /// </summary>
         public string LineRange { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether translated lines should be inserted
+        /// at the specified position instead of replacing existing lines in the target file.
+        /// </summary>
+        public bool InsertLines { get; set; }
     }
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/FileService/FileService.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/FileService/FileService.cs
@@ -70,4 +70,13 @@ internal class FileService : IFileService
         allLines.InsertRange(start, newLines);
         File.WriteAllLines(filePath, allLines);
     }
+
+    /// <inheritdoc/>
+    public void InsertLines(string filePath, int insertBeforeLine, string[] newLines)
+    {
+        var allLines = File.ReadAllLines(filePath).ToList();
+        int index = Math.Clamp(insertBeforeLine - 1, 0, allLines.Count);
+        allLines.InsertRange(index, newLines);
+        File.WriteAllLines(filePath, allLines);
+    }
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/FileService/IFileService.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/FileService/IFileService.cs
@@ -84,4 +84,12 @@ internal interface IFileService
     /// <param name="endLine">The 1-based ending line number to replace (inclusive).</param>
     /// <param name="newLines">The new lines to insert in place of the original range.</param>
     void ReplaceLines(string filePath, int startLine, int endLine, string[] newLines);
+
+    /// <summary>
+    /// Inserts lines into a file at the specified position without removing existing lines.
+    /// </summary>
+    /// <param name="filePath">The path to the file to modify.</param>
+    /// <param name="insertBeforeLine">The 1-based line number before which the new lines will be inserted.</param>
+    /// <param name="newLines">The new lines to insert.</param>
+    void InsertLines(string filePath, int insertBeforeLine, string[] newLines);
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/Program.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/Program.cs
@@ -57,6 +57,11 @@ namespace DocFXLanguageGenerator
                 aliases: ["--lines", "-r"],
                 description: "The range of lines to translate (e.g., '1-10' or '5-20'). Requires --sourcefile.");
 
+            var insertLinesOption = new Option<bool>(
+                aliases: ["--insert", "-i"],
+                description: "Insert translated lines at the specified position instead of replacing existing lines. Requires --lines.",
+                getDefaultValue: () => false);
+
             // Add options to root command
             rootCommand.AddOption(docFolderOption);
             rootCommand.AddOption(verboseOption);
@@ -66,6 +71,7 @@ namespace DocFXLanguageGenerator
             rootCommand.AddOption(checkOnlyOption);
             rootCommand.AddOption(sourceFileOption);
             rootCommand.AddOption(lineRangeOption);
+            rootCommand.AddOption(insertLinesOption);
 
             // Set command handler
             rootCommand.SetHandler(context =>
@@ -80,6 +86,7 @@ namespace DocFXLanguageGenerator
                     CheckOnly = context.ParseResult.GetValueForOption(checkOnlyOption),
                     SourceFile = context.ParseResult.GetValueForOption(sourceFileOption),
                     LineRange = context.ParseResult.GetValueForOption(lineRangeOption),
+                    InsertLines = context.ParseResult.GetValueForOption(insertLinesOption),
                 };
 
                 context.ExitCode = RunLogic(options);

--- a/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/LineInsertTranslationMode.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/TranslationMode/LineInsertTranslationMode.cs
@@ -1,0 +1,53 @@
+// Licensed to DocFX Companion Tools and contributors under one or more agreements.
+// DocFX Companion Tools and contributors licenses this file to you under the MIT license.
+
+using DocLanguageTranslator.FileService;
+
+namespace DocLanguageTranslator.TranslationMode;
+
+/// <summary>
+/// Translation mode for translating a specific range of lines and inserting them
+/// into an existing target file at the same position, without removing existing lines.
+/// </summary>
+internal class LineInsertTranslationMode : ITranslationMode
+{
+    private readonly int startLine;
+    private readonly int endLine;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LineInsertTranslationMode"/> class.
+    /// </summary>
+    /// <param name="startLine">The 1-based starting line number to read from the source file.</param>
+    /// <param name="endLine">The 1-based ending line number (inclusive) to read from the source file.</param>
+    public LineInsertTranslationMode(int startLine, int endLine)
+    {
+        this.startLine = startLine;
+        this.endLine = endLine;
+    }
+
+    /// <inheritdoc/>
+    public string ReadContent(IFileService fileService, string inputFile)
+    {
+        string[] sourceLines = fileService.ReadLines(inputFile, startLine, endLine);
+        return sourceLines.Length == 0 ? null : string.Join(Environment.NewLine, sourceLines);
+    }
+
+    /// <inheritdoc/>
+    public void WriteContent(IFileService fileService, string outputFile, string translatedContent)
+    {
+        string[] translatedLines = translatedContent.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
+        fileService.InsertLines(outputFile, startLine, translatedLines);
+    }
+
+    /// <inheritdoc/>
+    public string FormatStartMessage(string inputFile, string outputFile, string sourceLang, string targetLang)
+        => $"Translating lines {startLine}-{endLine} from {inputFile} and inserting into {outputFile} [{sourceLang} to {targetLang}]";
+
+    /// <inheritdoc/>
+    public string FormatCompletionMessage(string outputFile)
+        => $"Inserted translated lines at position {startLine} in {outputFile}";
+
+    /// <inheritdoc/>
+    public string GetNoContentErrorMessage()
+        => $"ERROR: No lines found in range {startLine}-{endLine}.";
+}

--- a/src/DocLanguageTranslator/README.md
+++ b/src/DocLanguageTranslator/README.md
@@ -48,6 +48,7 @@ Options:
   -c, --check                             Check missing files in structure only. [default: False]
   -f, --sourcefile <sourcefile>           The source file path for line range translation.
   -r, --lines <lines>                     The range of lines to translate (e.g., '1-10'). Requires --sourcefile.
+  -i, --insert                            Insert translated lines instead of replacing. Requires --lines. [default: False]
   --version                               Show version information
   -?, -h, --help                          Show help and usage information
 ```
@@ -180,6 +181,27 @@ This command will:
 * If a target file doesn't exist, a warning will be displayed and that language will be skipped
 * Use the `--check` option with `--lines` to verify that target files exist without translating
 * When using `--check` with `--lines`, verbose output (`-v`) will display which files would be translated and show the specific lines that would be translated
+
+### Inserting lines instead of replacing
+
+By default, `--lines` **replaces** the corresponding lines in each target file. If you have added new lines to the source file and want to **insert** the translated text into the target files at the same position (without overwriting existing lines), use the `--insert` (or `-i`) flag.
+
+**Example:**
+
+```bash
+DocLanguageTranslator -d c:\path\userdocs -k your-key -f c:\path\userdocs\en\toc.yml -r 5-7 --insert
+```
+
+This command will:
+
+1. Read lines 5-7 from `c:\path\userdocs\en\toc.yml`
+2. Translate those lines to all other language directories (e.g., `de`, `fr`, `zh-Hans`)
+3. Insert the translated lines before line 5 in each target file, preserving all existing content
+
+| Flag | Behavior |
+|---|---|
+| `--lines 5-7` (default) | Replaces lines 5–7 in each target file with translated content |
+| `--lines 5-7 --insert` | Inserts translated content before line 5 in each target file, keeping all existing lines |
 
 **Check-only mode example:**
 


### PR DESCRIPTION
Adds support for --insert/-i to insert (not replace) translated lines when using --lines. Introduces LineInsertTranslationMode, updates IFileService with InsertLines, and adjusts logic to select between insert and replace modes. Improves verbose/check-only output to reflect action. Updates tests and README with usage and examples.

Fixes #126 