### PR TITLE
Add support for specifying target languages

### DIFF
--- a/src/DocLanguageTranslator/DocLanguageTranslator.Test/DocFxLanguageGeneratorTests.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator.Test/DocFxLanguageGeneratorTests.cs
@@ -869,4 +869,125 @@ public sealed class DocFxLanguageGeneratorTests
         Assert.Contains(mockMessageHelper.VerboseMessages, m => m.Contains("Would translate and insert lines 2-2"));
         mockTranslationService.Verify(t => t.TranslateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
+
+    [Fact]
+    public void Run_WithTargetLanguages_OnlyTranslatesToSpecifiedLanguages()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+        mockFileService.CreateDirectory("docs/de");
+        mockFileService.CreateDirectory("docs/fr");
+        mockFileService.CreateDirectory("docs/es");
+        mockFileService.WriteAllText("docs/en/file1.md", "# Hello");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            Key = "valid-key",
+            Verbose = true,
+            SourceLanguage = "en",
+            TargetLanguages = ["de", "fr"],
+        };
+
+        mockTranslationService
+            .Setup(t => t.TranslateAsync(It.IsAny<string>(), "en", "de"))
+            .ReturnsAsync("# Hallo");
+        mockTranslationService
+            .Setup(t => t.TranslateAsync(It.IsAny<string>(), "en", "fr"))
+            .ReturnsAsync("# Bonjour");
+
+        var generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(0, returnValue);
+        Assert.True(mockFileService.Files.ContainsKey("docs/de/file1.md"));
+        Assert.True(mockFileService.Files.ContainsKey("docs/fr/file1.md"));
+        Assert.False(mockFileService.Files.ContainsKey("docs/es/file1.md"));
+        mockTranslationService.Verify(t => t.TranslateAsync(It.IsAny<string>(), It.IsAny<string>(), "es"), Times.Never);
+    }
+
+    [Fact]
+    public void Run_WithoutTargetLanguages_AutoDiscoversAllLanguages()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+        mockFileService.CreateDirectory("docs/de");
+        mockFileService.CreateDirectory("docs/fr");
+        mockFileService.WriteAllText("docs/en/file1.md", "# Hello");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            Key = "valid-key",
+            Verbose = true,
+            SourceLanguage = "en",
+            TargetLanguages = null,
+        };
+
+        mockTranslationService
+            .Setup(t => t.TranslateAsync(It.IsAny<string>(), "en", "de"))
+            .ReturnsAsync("# Hallo");
+        mockTranslationService
+            .Setup(t => t.TranslateAsync(It.IsAny<string>(), "en", "fr"))
+            .ReturnsAsync("# Bonjour");
+
+        var generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(0, returnValue);
+        Assert.True(mockFileService.Files.ContainsKey("docs/de/file1.md"));
+        Assert.True(mockFileService.Files.ContainsKey("docs/fr/file1.md"));
+    }
+
+    [Fact]
+    public void Run_WithTargetLanguages_CreatesDirectoryForNewLanguage()
+    {
+        // Arrange
+        mockFileService.CreateDirectory("docs");
+        mockFileService.CreateDirectory("docs/en");
+        mockFileService.WriteAllText("docs/en/file1.md", "# Hello");
+
+        CommandlineOptions options = new CommandlineOptions
+        {
+            DocFolder = "docs",
+            Key = "valid-key",
+            Verbose = true,
+            SourceLanguage = "en",
+            TargetLanguages = ["de"],
+        };
+
+        mockTranslationService
+            .Setup(t => t.TranslateAsync(It.IsAny<string>(), "en", "de"))
+            .ReturnsAsync("# Hallo");
+
+        var generator = new DocFxLanguageGenerator(
+            options,
+            mockFileService,
+            mockTranslationService.Object,
+            mockMessageHelper);
+
+        // Act
+        int returnValue = generator.Run();
+
+        // Assert
+        Assert.Equal(0, returnValue);
+        Assert.True(mockFileService.Files.ContainsKey("docs/de/file1.md"));
+        Assert.Contains("# Hallo", mockFileService.Files["docs/de/file1.md"]);
+    }
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/DocFxLanguageGenerator.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/DocFxLanguageGenerator.cs
@@ -61,6 +61,7 @@ namespace DocFXLanguageGenerator
             messageHelper.Verbose($"Key                 : {options.Key}");
             messageHelper.Verbose($"Location            : {options.Location}");
             messageHelper.Verbose($"Source language     : {options.SourceLanguage}");
+            messageHelper.Verbose($"Target languages    : {(options.TargetLanguages != null && options.TargetLanguages.Length > 0 ? string.Join(", ", options.TargetLanguages) : "(auto-discover)")}");
             messageHelper.Verbose($"Source file         : {options.SourceFile}");
             messageHelper.Verbose($"Line range          : {options.LineRange}");
             messageHelper.Verbose($"Insert lines        : {options.InsertLines}");
@@ -87,6 +88,7 @@ namespace DocFXLanguageGenerator
             // We expect to have sub folders like ./userdocs/en ./userdocs/de, etc
             string rootDirectory = options.DocFolder;
             var allLanguagesDirectories = FindAllRootLanguages(rootDirectory);
+            var targetLanguagesDirectories = GetTargetLanguageDirectories(rootDirectory, allLanguagesDirectories);
 
             // use the source language if it is specified
             var sourceLanguageDirectories = options.SourceLanguage != null
@@ -102,7 +104,7 @@ namespace DocFXLanguageGenerator
                 // checked that the file exists in other directories
                 foreach (var file in allTranslatableFiles)
                 {
-                    foreach (var lgDir in allLanguagesDirectories)
+                    foreach (var lgDir in targetLanguagesDirectories)
                     {
                         if (langDir == lgDir)
                         {
@@ -266,6 +268,19 @@ namespace DocFXLanguageGenerator
                 .ToArray();
         }
 
+        private string[] GetTargetLanguageDirectories(string rootDirectory, string[] allLanguagesDirectories)
+        {
+            if (options.TargetLanguages == null || options.TargetLanguages.Length == 0)
+            {
+                return allLanguagesDirectories;
+            }
+
+            // Build paths for the specified target languages
+            return options.TargetLanguages
+                .Select(lang => Path.Combine(rootDirectory, lang).Replace('\\', '/'))
+                .ToArray();
+        }
+
         private bool TranslateFile(
             string inputFile,
             string sourceLang,
@@ -405,6 +420,7 @@ namespace DocFXLanguageGenerator
 
             string rootDirectory = options.DocFolder;
             var allLanguagesDirectories = FindAllRootLanguages(rootDirectory);
+            var targetLanguagesDirectories = GetTargetLanguageDirectories(rootDirectory, allLanguagesDirectories);
 
             // Find the source language directory by checking which language directory contains the source file
             string normalizedSourceFile = options.SourceFile.Replace('\\', '/');
@@ -429,7 +445,7 @@ namespace DocFXLanguageGenerator
 
             int numberOfFiles = 0;
 
-            foreach (var langDir in allLanguagesDirectories)
+            foreach (var langDir in targetLanguagesDirectories)
             {
                 string normalizedLangDir = langDir.Replace('\\', '/');
                 string targetLang = GetLanguageCodeFromPath(langDir);

--- a/src/DocLanguageTranslator/DocLanguageTranslator/Domain/CommandlineOptions.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/Domain/CommandlineOptions.cs
@@ -53,5 +53,12 @@ namespace DocFXLanguageGenerator.Domain
         /// at the specified position instead of replacing existing lines in the target file.
         /// </summary>
         public bool InsertLines { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target language codes to translate to.
+        /// When specified, only these languages are used as translation targets.
+        /// When null or empty, languages are auto-discovered from folder names.
+        /// </summary>
+        public string[] TargetLanguages { get; set; }
     }
 }

--- a/src/DocLanguageTranslator/DocLanguageTranslator/Program.cs
+++ b/src/DocLanguageTranslator/DocLanguageTranslator/Program.cs
@@ -53,6 +53,13 @@ namespace DocFXLanguageGenerator
                 aliases: ["--sourcefile", "-f"],
                 description: "The source file path for line range translation.");
 
+            var languagesOption = new Option<string[]>(
+                aliases: ["--languages", "-t"],
+                description: "One or more target language codes to translate to (e.g., 'de' 'fr' 'zh-Hans'). If not specified, languages are auto-discovered from folder names.")
+            {
+                AllowMultipleArgumentsPerToken = true,
+            };
+
             var lineRangeOption = new Option<string>(
                 aliases: ["--lines", "-r"],
                 description: "The range of lines to translate (e.g., '1-10' or '5-20'). Requires --sourcefile.");
@@ -70,6 +77,7 @@ namespace DocFXLanguageGenerator
             rootCommand.AddOption(sourceLanguageOption);
             rootCommand.AddOption(checkOnlyOption);
             rootCommand.AddOption(sourceFileOption);
+            rootCommand.AddOption(languagesOption);
             rootCommand.AddOption(lineRangeOption);
             rootCommand.AddOption(insertLinesOption);
 
@@ -83,6 +91,7 @@ namespace DocFXLanguageGenerator
                     Key = context.ParseResult.GetValueForOption(keyOption),
                     Location = context.ParseResult.GetValueForOption(locationOption),
                     SourceLanguage = context.ParseResult.GetValueForOption(sourceLanguageOption),
+                    TargetLanguages = context.ParseResult.GetValueForOption(languagesOption),
                     CheckOnly = context.ParseResult.GetValueForOption(checkOnlyOption),
                     SourceFile = context.ParseResult.GetValueForOption(sourceFileOption),
                     LineRange = context.ParseResult.GetValueForOption(lineRangeOption),

--- a/src/DocLanguageTranslator/README.md
+++ b/src/DocLanguageTranslator/README.md
@@ -45,6 +45,7 @@ Options:
   -k, --key <key>                         The translator Azure Cognitive Services key.
   -l, --location <location>               The translator Azure Cognitive Services location. [default: westeurope]
   -s, --source <language>                 The source language of files to use for missing translations.
+  -t, --languages <lang1> [<lang2>...]    One or more target language codes to translate to. If not specified, languages are auto-discovered from folder names.
   -c, --check                             Check missing files in structure only. [default: False]
   -f, --sourcefile <sourcefile>           The source file path for line range translation.
   -r, --lines <lines>                     The range of lines to translate (e.g., '1-10'). Requires --sourcefile.
@@ -151,6 +152,20 @@ To explicitly set the source language, pass the language code to the `-s or --so
 
 In this case, only missing files which exist in the source language directory will be used for translations.
 
+### Target languages
+
+By default, the tool auto-discovers target languages by enumerating subdirectories that match valid culture names (e.g., `en`, `de`, `fr`, `zh-Hans`).
+
+To translate only to specific languages, use the `-t or --languages` option with one or more language codes:
+
+```bash
+DocLanguageTranslator -d c:\path\userdocs -k your-key -s en -t de fr
+```
+
+This will only translate missing files from `en` to `de` and `fr`, even if other language directories exist.
+
+If the target language directory does not yet exist, the tool will create it automatically.
+
 ### Translating specific line ranges
 
 If you only need to translate a specific range of lines from a source document (instead of the entire file), you can use the `-r or --lines` option together with the `-f or --sourcefile` option.
@@ -200,7 +215,7 @@ This command will:
 
 | Flag | Behavior |
 |---|---|
-| `--lines 5-7` (default) | Replaces lines 5–7 in each target file with translated content |
+| `--lines 5-7` (default) | Replaces lines 5â€“7 in each target file with translated content |
 | `--lines 5-7 --insert` | Inserts translated content before line 5 in each target file, keeping all existing lines |
 
 **Check-only mode example:**


### PR DESCRIPTION
Added -t/--languages option to restrict translation targets. Updated translation logic to use only specified languages or auto-discover if not set. Enhanced verbose output and documentation. Added tests for new behavior.

Fixes #128