### PR TITLE
Removing next version in CI/CD publish

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,4 @@
 mode: ContinuousDelivery
-next-version: 2.0.0
 branches:
   main:
     regex: ^main


### PR DESCRIPTION
Removing next version in CI/CD publish as now v2 is out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a fixed version setting so application versioning can be determined automatically.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->